### PR TITLE
dd/qd import fixes

### DIFF
--- a/src/fpylll/fplll/bkz.pyx
+++ b/src/fpylll/fplll/bkz.pyx
@@ -10,7 +10,7 @@ Block Korkine Zolotarev algorithm.
 
 IF HAVE_QD:
     from decl cimport mpz_dd, mpz_qd
-    from qd.qd cimport dd_real, qd_real
+    from fpylll.qd.qd cimport dd_real, qd_real
 
 from bkz_param cimport BKZParam
 from decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr, vector_fp_nr_t, fp_nr_t

--- a/src/fpylll/fplll/decl.pxd
+++ b/src/fpylll/fplll/decl.pxd
@@ -10,7 +10,7 @@ from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t
 
 IF HAVE_QD:
-    from qd.qd cimport dd_real, qd_real
+    from fpylll.qd.qd cimport dd_real, qd_real
 
 from fplll cimport dpe_t
 from fplll cimport Z_NR, FP_NR

--- a/src/fpylll/fplll/enumeration.pyx
+++ b/src/fpylll/fplll/enumeration.pyx
@@ -16,8 +16,8 @@ from decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr
 from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
 
 IF HAVE_QD:
-    from qd.qd cimport dd_real, qd_real
-    from fpylll cimport mpz_dd, mpz_qd
+    from fpylll.qd.qd cimport dd_real, qd_real
+    from decl cimport mpz_dd, mpz_qd
     from fplll cimport FT_DD, FT_QD
 
 class EnumerationError(Exception):

--- a/src/fpylll/fplll/gso.pyx
+++ b/src/fpylll/fplll/gso.pyx
@@ -24,8 +24,8 @@ from fpylll.util cimport preprocess_indices, check_float_type
 from integer_matrix cimport IntegerMatrix
 
 IF HAVE_QD:
-    from qd.qd cimport dd_real, qd_real
-    from fpylll cimport mpz_dd, mpz_qd
+    from fpylll.qd.qd cimport dd_real, qd_real
+    from decl cimport mpz_dd, mpz_qd
     from fplll cimport FT_DD, FT_QD
 
 

--- a/src/fpylll/fplll/lll.pyx
+++ b/src/fpylll/fplll/lll.pyx
@@ -31,8 +31,8 @@ from fpylll.util import ReductionError
 from decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr
 
 IF HAVE_QD:
-    from qd.qd cimport dd_real, qd_real
-    from fpylll cimport mpz_dd, mpz_qd
+    from fpylll.qd.qd cimport dd_real, qd_real
+    from decl cimport mpz_dd, mpz_qd
 
 from wrapper import Wrapper
 

--- a/src/fpylll/numpy.pyx
+++ b/src/fpylll/numpy.pyx
@@ -7,7 +7,7 @@ from fpylll.fplll.gso cimport MatGSO
 from fpylll.fplll.decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr
 
 IF HAVE_QD:
-    from fpylll cimport mpz_dd, mpz_qd
+    from fpylll.fplll.decl cimport mpz_dd, mpz_qd
 
 IF not HAVE_NUMPY:
     raise ImportError("NumPy is not installed, but this module relies on it.")

--- a/src/fpylll/util.pyx
+++ b/src/fpylll/util.pyx
@@ -13,8 +13,8 @@ from fpylll.gmp.random cimport gmp_randstate_t, gmp_randseed_ui
 from fpylll.mpfr.mpfr cimport mpfr_t
 
 IF HAVE_QD:
-    from qd.qd cimport dd_real, qd_real
-    from fplll cimport FT_DD, FT_QD
+    from fpylll.qd.qd cimport dd_real, qd_real
+    from fpylll.fplll.fplll cimport FT_DD, FT_QD
 
 
 float_aliases = {'d': 'double',


### PR DESCRIPTION
Few fixes for the imports when qd is available.
However setup.py won't see that it is, since the fplll.pc file doesn't display the -lqd flag. At least in my context with qd installed and correctly linked during fplll compilation.
Maybe a "bug" in the configure.ac of fplll?