### PR TITLE
Disable long double functionality where not available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,12 @@ if have_numpy:
 else:
     config_pxi.append("DEF HAVE_NUMPY=False")
 
+# Ideally this would check the fplll headers explicitly for the
+# the FPLLL_WITH_LONG_DOUBLE define, but for now it suffices to
+# say that long double support is disabled on Cygwin
+have_long_double = not sys.platform.startswith('cygwin')
+config_pxi.append("DEF HAVE_LONG_DOUBLE={0}".format(have_long_double))
+
 
 # CONFIG.PXI
 config_pxi_path = os.path.join(".", "src", "fpylll", "config.pxi")

--- a/src/fpylll/config.pyx
+++ b/src/fpylll/config.pyx
@@ -6,12 +6,19 @@ include "cysignals/signals.pxi"
 from fplll.fplll cimport default_strategy as default_strategy_c
 from fplll.fplll cimport default_strategy_path as default_strategy_path_c
 
+IF HAVE_LONG_DOUBLE:
+    have_long_double = True
+    float_types = ("d", "ld")
+ELSE:
+    have_long_double = False
+    float_types = ("d",)
+
 IF HAVE_QD:
     have_qd = True
-    float_types = ("d", "ld", "dpe", "dd", "qd", "mpfr")
+    float_types = float_types + ("dpe", "dd", "qd", "mpfr")
 ELSE:
     have_qd = False
-    float_types = ("d", "ld", "dpe", "mpfr")
+    float_types = float_types + ("dpe", "mpfr")
 
 IF HAVE_SAGE:
     have_sage = True

--- a/src/fpylll/fplll/bkz.pyx
+++ b/src/fpylll/fplll/bkz.pyx
@@ -54,10 +54,13 @@ cdef class BKZAutoAbort:
                                                                       num_rows,
                                                                       start_row)
         elif M._type == mpz_ld:
-            self._type = mpz_ld
-            self._core.mpz_ld = new BKZAutoAbort_c[FP_NR[longdouble]](M._core.mpz_ld[0],
-                                                          num_rows,
-                                                          start_row)
+            IF HAVE_LONG_DOUBLE:
+                self._type = mpz_ld
+                self._core.mpz_ld = new BKZAutoAbort_c[FP_NR[longdouble]](M._core.mpz_ld[0],
+                                                              num_rows,
+                                                              start_row)
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif M._type == mpz_dpe:
             self._type = mpz_dpe
             self._core.mpz_dpe = new BKZAutoAbort_c[FP_NR[dpe_t]](M._core.mpz_dpe[0],
@@ -98,7 +101,10 @@ cdef class BKZAutoAbort:
         if self._type == mpz_double:
             return self._core.mpz_double.test_abort(scale, max_no_dec)
         elif self._type == mpz_ld:
-            return self._core.mpz_ld.test_abort(scale, max_no_dec)
+            IF HAVE_LONG_DOUBLE:
+                return self._core.mpz_ld.test_abort(scale, max_no_dec)
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             return self._core.mpz_dpe.test_abort(scale, max_no_dec)
         elif self._type == mpz_mpfr:
@@ -133,10 +139,13 @@ cdef class BKZReduction:
                                                                       self.lll_obj._core.mpz_double[0],
                                                                       param.o[0])
         elif M._type == mpz_ld:
-            self._type = mpz_ld
-            self._core.mpz_ld = new BKZReduction_c[FP_NR[longdouble]](self.M._core.mpz_ld[0],
-                                                                      self.lll_obj._core.mpz_ld[0],
-                                                                      param.o[0])
+            IF HAVE_LONG_DOUBLE:
+                self._type = mpz_ld
+                self._core.mpz_ld = new BKZReduction_c[FP_NR[longdouble]](self.M._core.mpz_ld[0],
+                                                                          self.lll_obj._core.mpz_ld[0],
+                                                                          param.o[0])
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif M._type == mpz_dpe:
             self._type = mpz_dpe
             self._core.mpz_dpe = new BKZReduction_c[FP_NR[dpe_t]](self.M._core.mpz_dpe[0],
@@ -167,8 +176,9 @@ cdef class BKZReduction:
     def __dealloc__(self):
         if self._type == mpz_double:
             del self._core.mpz_double
-        if self._type == mpz_ld:
-            del self._core.mpz_ld
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                del self._core.mpz_ld
         if self._type == mpz_dpe:
             del self._core.mpz_dpe
         IF HAVE_QD:
@@ -194,9 +204,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.bkz()
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.bkz()
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.bkz()
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.bkz()
@@ -239,9 +252,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.svp_preprocessing(kappa, block_size, param.o[0])
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.svp_preprocessing(kappa, block_size, param.o[0])
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.svp_preprocessing(kappa, block_size, param.o[0])
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.svp_preprocessing(kappa, block_size, param.o[0])
@@ -291,12 +307,15 @@ cdef class BKZReduction:
             r = self._core.mpz_double.svp_postprocessing(kappa, block_size, solution_.double)
             sig_off()
         elif self._type == mpz_ld:
-            for s in solution:
-                t.ld = float(s)
-                solution_.ld.push_back(t.ld)
-            sig_on()
-            r = self._core.mpz_ld.svp_postprocessing(kappa, block_size, solution_.ld)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                for s in solution:
+                    t.ld = float(s)
+                    solution_.ld.push_back(t.ld)
+                sig_on()
+                r = self._core.mpz_ld.svp_postprocessing(kappa, block_size, solution_.ld)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             for s in solution:
                 t.dpe = float(s)
@@ -358,12 +377,15 @@ cdef class BKZReduction:
             r = self._core.mpz_double.dsvp_postprocessing(kappa, block_size, solution_.double)
             sig_off()
         elif self._type == mpz_ld:
-            for s in solution:
-                t.ld = float(s)
-                solution_.ld.push_back(t.ld)
-            sig_on()
-            r = self._core.mpz_ld.dsvp_postprocessing(kappa, block_size, solution_.ld)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                for s in solution:
+                    t.ld = float(s)
+                    solution_.ld.push_back(t.ld)
+                sig_on()
+                r = self._core.mpz_ld.dsvp_postprocessing(kappa, block_size, solution_.ld)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             for s in solution:
                 t.dpe = float(s)
@@ -420,9 +442,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.svp_reduction(kappa, block_size, param.o[0], int(dual))
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.svp_reduction(kappa, block_size, param.o[0], dual)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.svp_reduction(kappa, block_size, param.o[0], dual)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.svp_reduction(kappa, block_size, param.o[0], dual)
@@ -468,9 +493,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.tour(loop, kappa_max, param.o[0], min_row, max_row)
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.tour(loop, kappa_max, param.o[0], min_row, max_row)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.tour(loop, kappa_max, param.o[0], min_row, max_row)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.tour(loop, kappa_max, param.o[0], min_row, max_row)
@@ -515,9 +543,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.sd_tour(loop, param.o[0], min_row, max_row)
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.sd_tour(loop, param.o[0], min_row, max_row)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.sd_tour(loop, param.o[0], min_row, max_row)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.sd_tour(loop, param.o[0], min_row, max_row)
@@ -564,9 +595,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.slide_tour(loop, param.o[0], min_row, max_row)
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.slide_tour(loop, param.o[0], min_row, max_row)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.slide_tour(loop, param.o[0], min_row, max_row)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.slide_tour(loop, param.o[0], min_row, max_row)
@@ -614,9 +648,12 @@ cdef class BKZReduction:
             r = self._core.mpz_double.hkz(kappa_max, param.o[0], min_row, max_row)
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.hkz(kappa_max, param.o[0], min_row, max_row)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                r = self._core.mpz_ld.hkz(kappa_max, param.o[0], min_row, max_row)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.hkz(kappa_max, param.o[0], min_row, max_row)
@@ -652,9 +689,12 @@ cdef class BKZReduction:
             self._core.mpz_double.rerandomize_block(min_row, max_row, density)
             sig_off()
         elif self._type == mpz_ld:
-            sig_on()
-            self._core.mpz_ld.rerandomize_block(min_row, max_row, density)
-            sig_off()
+            IF HAVE_LONG_DOUBLE:
+                sig_on()
+                self._core.mpz_ld.rerandomize_block(min_row, max_row, density)
+                sig_off()
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             sig_on()
             self._core.mpz_dpe.rerandomize_block(min_row, max_row, density)
@@ -684,7 +724,10 @@ cdef class BKZReduction:
         if self._type == mpz_double:
             return self._core.mpz_double.status
         elif self._type == mpz_ld:
-            return self._core.mpz_ld.status
+            IF HAVE_LONG_DOUBLE:
+                return self._core.mpz_ld.status
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             return self._core.mpz_dpe.status
         elif self._type == mpz_mpfr:
@@ -706,7 +749,10 @@ cdef class BKZReduction:
         if self._type == mpz_double:
             return self._core.mpz_double.nodes
         elif self._type == mpz_ld:
-            return self._core.mpz_ld.nodes
+            IF HAVE_LONG_DOUBLE:
+                return self._core.mpz_ld.nodes
+            ELSE:
+                raise RuntimeError("BKZAutoAbort object '%s' has no core."%self)
         elif self._type == mpz_dpe:
             return self._core.mpz_dpe.nodes
         elif self._type == mpz_mpfr:

--- a/src/fpylll/fplll/decl.pxd
+++ b/src/fpylll/fplll/decl.pxd
@@ -33,124 +33,231 @@ ELSE:
         mpz_dpe    =  4
         mpz_mpfr   = 32
 
-IF HAVE_QD:
-    # we cannot use a union because of non-trivial constructors
-    ctypedef struct fp_nr_t:
-        FP_NR[double] double
-        FP_NR[longdouble] ld
-        FP_NR[dpe_t] dpe
-        FP_NR[dd_real] dd
-        FP_NR[qd_real] qd
-        FP_NR[mpfr_t] mpfr
-ELSE:
-    ctypedef struct fp_nr_t:
-        FP_NR[double] double
-        FP_NR[longdouble] ld
-        FP_NR[dpe_t] dpe
-        FP_NR[mpfr_t] mpfr
+IF HAVE_LONG_DOUBLE:
+    IF HAVE_QD:
+        # we cannot use a union because of non-trivial constructors
+        ctypedef struct fp_nr_t:
+            FP_NR[double] double
+            FP_NR[longdouble] ld
+            FP_NR[dpe_t] dpe
+            FP_NR[dd_real] dd
+            FP_NR[qd_real] qd
+            FP_NR[mpfr_t] mpfr
+    ELSE:
+        ctypedef struct fp_nr_t:
+            FP_NR[double] double
+            FP_NR[longdouble] ld
+            FP_NR[dpe_t] dpe
+            FP_NR[mpfr_t] mpfr
 
-IF HAVE_QD:
-    ctypedef union mat_gso_core_t:
-        MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
-        MatGSO[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
-        MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
-        MatGSO[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
-        MatGSO[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
-        MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
-ELSE:
-    ctypedef union mat_gso_core_t:
-        MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
-        MatGSO[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
-        MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
-        MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    IF HAVE_QD:
+        ctypedef union mat_gso_core_t:
+            MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            MatGSO[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
+            MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            MatGSO[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
+            MatGSO[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
+            MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union mat_gso_core_t:
+            MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            MatGSO[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
+            MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
 
-IF HAVE_QD:
-    ctypedef union lll_reduction_core_t:
-        LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
-        LLLReduction[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
-        LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
-        LLLReduction[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
-        LLLReduction[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
-        LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
-ELSE:
-    ctypedef union lll_reduction_core_t:
-        LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
-        LLLReduction[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
-        LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
-        LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    IF HAVE_QD:
+        ctypedef union lll_reduction_core_t:
+            LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            LLLReduction[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
+            LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            LLLReduction[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
+            LLLReduction[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
+            LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union lll_reduction_core_t:
+            LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            LLLReduction[Z_NR[mpz_t], FP_NR[longdouble]] *mpz_ld
+            LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
 
-IF HAVE_QD:
-    ctypedef union bkz_auto_abort_core_t:
-        BKZAutoAbort[FP_NR[double]] *mpz_double
-        BKZAutoAbort[FP_NR[longdouble]] *mpz_ld
-        BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
-        BKZAutoAbort[FP_NR[dd_real]] *mpz_dd
-        BKZAutoAbort[FP_NR[qd_real]] *mpz_qd
-        BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
-ELSE:
-    ctypedef union bkz_auto_abort_core_t:
-        BKZAutoAbort[FP_NR[double]] *mpz_double
-        BKZAutoAbort[FP_NR[longdouble]] *mpz_ld
-        BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
-        BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
+    IF HAVE_QD:
+        ctypedef union bkz_auto_abort_core_t:
+            BKZAutoAbort[FP_NR[double]] *mpz_double
+            BKZAutoAbort[FP_NR[longdouble]] *mpz_ld
+            BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
+            BKZAutoAbort[FP_NR[dd_real]] *mpz_dd
+            BKZAutoAbort[FP_NR[qd_real]] *mpz_qd
+            BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union bkz_auto_abort_core_t:
+            BKZAutoAbort[FP_NR[double]] *mpz_double
+            BKZAutoAbort[FP_NR[longdouble]] *mpz_ld
+            BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
+            BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
 
-IF HAVE_QD:
-    ctypedef union bkz_reduction_core_t:
-        BKZReduction[FP_NR[double]] *mpz_double
-        BKZReduction[FP_NR[longdouble]] *mpz_ld
-        BKZReduction[FP_NR[dpe_t]] *mpz_dpe
-        BKZReduction[FP_NR[dd_real]] *mpz_dd
-        BKZReduction[FP_NR[qd_real]] *mpz_qd
-        BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
-ELSE:
-    ctypedef union bkz_reduction_core_t:
-        BKZReduction[FP_NR[double]] *mpz_double
-        BKZReduction[FP_NR[longdouble]] *mpz_ld
-        BKZReduction[FP_NR[dpe_t]] *mpz_dpe
-        BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
+    IF HAVE_QD:
+        ctypedef union bkz_reduction_core_t:
+            BKZReduction[FP_NR[double]] *mpz_double
+            BKZReduction[FP_NR[longdouble]] *mpz_ld
+            BKZReduction[FP_NR[dpe_t]] *mpz_dpe
+            BKZReduction[FP_NR[dd_real]] *mpz_dd
+            BKZReduction[FP_NR[qd_real]] *mpz_qd
+            BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union bkz_reduction_core_t:
+            BKZReduction[FP_NR[double]] *mpz_double
+            BKZReduction[FP_NR[longdouble]] *mpz_ld
+            BKZReduction[FP_NR[dpe_t]] *mpz_dpe
+            BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
 
-IF HAVE_QD:
-    ctypedef union fast_evaluator_core_t:
-        FastEvaluator[FP_NR[double]] *double
-        FastEvaluator[FP_NR[longdouble]] *ld
-        FastEvaluator[FP_NR[dpe_t]] *dpe
-        FastEvaluator[FP_NR[dd_real]] *dd
-        FastEvaluator[FP_NR[qd_real]] *qd
-        FastEvaluator[FP_NR[mpfr_t]] *mpfr
-ELSE:
-    ctypedef union fast_evaluator_core_t:
-        FastEvaluator[FP_NR[double]] *double
-        FastEvaluator[FP_NR[longdouble]] *ld
-        FastEvaluator[FP_NR[dpe_t]] *dpe
-        FastEvaluator[FP_NR[mpfr_t]] *mpfr
+    IF HAVE_QD:
+        ctypedef union fast_evaluator_core_t:
+            FastEvaluator[FP_NR[double]] *double
+            FastEvaluator[FP_NR[longdouble]] *ld
+            FastEvaluator[FP_NR[dpe_t]] *dpe
+            FastEvaluator[FP_NR[dd_real]] *dd
+            FastEvaluator[FP_NR[qd_real]] *qd
+            FastEvaluator[FP_NR[mpfr_t]] *mpfr
+    ELSE:
+        ctypedef union fast_evaluator_core_t:
+            FastEvaluator[FP_NR[double]] *double
+            FastEvaluator[FP_NR[longdouble]] *ld
+            FastEvaluator[FP_NR[dpe_t]] *dpe
+            FastEvaluator[FP_NR[mpfr_t]] *mpfr
 
-IF HAVE_QD:
-    ctypedef union enumeration_core_t:
-        Enumeration[FP_NR[double]] *double
-        Enumeration[FP_NR[longdouble]] *ld
-        Enumeration[FP_NR[dpe_t]] *dpe
-        Enumeration[FP_NR[dd_real]] *dd
-        Enumeration[FP_NR[qd_real]] *qd
-        Enumeration[FP_NR[mpfr_t]] *mpfr
-ELSE:
-    ctypedef union enumeration_core_t:
-        Enumeration[FP_NR[double]] *double
-        Enumeration[FP_NR[longdouble]] *ld
-        Enumeration[FP_NR[dpe_t]] *dpe
-        Enumeration[FP_NR[mpfr_t]] *mpfr
+    IF HAVE_QD:
+        ctypedef union enumeration_core_t:
+            Enumeration[FP_NR[double]] *double
+            Enumeration[FP_NR[longdouble]] *ld
+            Enumeration[FP_NR[dpe_t]] *dpe
+            Enumeration[FP_NR[dd_real]] *dd
+            Enumeration[FP_NR[qd_real]] *qd
+            Enumeration[FP_NR[mpfr_t]] *mpfr
+    ELSE:
+        ctypedef union enumeration_core_t:
+            Enumeration[FP_NR[double]] *double
+            Enumeration[FP_NR[longdouble]] *ld
+            Enumeration[FP_NR[dpe_t]] *dpe
+            Enumeration[FP_NR[mpfr_t]] *mpfr
 
-IF HAVE_QD:
-    # we cannot use a union because of non-trivial constructors
-    ctypedef struct vector_fp_nr_t:
-        vector[FP_NR[double]] double
-        vector[FP_NR[longdouble]] ld
-        vector[FP_NR[dpe_t]] dpe
-        vector[FP_NR[dd_real]] dd
-        vector[FP_NR[qd_real]] qd
-        vector[FP_NR[mpfr_t]] mpfr
+    IF HAVE_QD:
+        # we cannot use a union because of non-trivial constructors
+        ctypedef struct vector_fp_nr_t:
+            vector[FP_NR[double]] double
+            vector[FP_NR[longdouble]] ld
+            vector[FP_NR[dpe_t]] dpe
+            vector[FP_NR[dd_real]] dd
+            vector[FP_NR[qd_real]] qd
+            vector[FP_NR[mpfr_t]] mpfr
+    ELSE:
+        ctypedef struct vector_fp_nr_t:
+            vector[FP_NR[double]] double
+            vector[FP_NR[longdouble]] ld
+            vector[FP_NR[dpe_t]] dpe
+            vector[FP_NR[mpfr_t]] mpfr
 ELSE:
-    ctypedef struct vector_fp_nr_t:
-        vector[FP_NR[double]] double
-        vector[FP_NR[longdouble]] ld
-        vector[FP_NR[dpe_t]] dpe
-        vector[FP_NR[mpfr_t]] mpfr
+    IF HAVE_QD:
+        # we cannot use a union because of non-trivial constructors
+        ctypedef struct fp_nr_t:
+            FP_NR[double] double
+            FP_NR[dpe_t] dpe
+            FP_NR[dd_real] dd
+            FP_NR[qd_real] qd
+            FP_NR[mpfr_t] mpfr
+    ELSE:
+        ctypedef struct fp_nr_t:
+            FP_NR[double] double
+            FP_NR[dpe_t] dpe
+            FP_NR[mpfr_t] mpfr
+
+    IF HAVE_QD:
+        ctypedef union mat_gso_core_t:
+            MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            MatGSO[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
+            MatGSO[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
+            MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union mat_gso_core_t:
+            MatGSO[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            MatGSO[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            MatGSO[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+
+    IF HAVE_QD:
+        ctypedef union lll_reduction_core_t:
+            LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            LLLReduction[Z_NR[mpz_t], FP_NR[dd_real]] *mpz_dd
+            LLLReduction[Z_NR[mpz_t], FP_NR[qd_real]] *mpz_qd
+            LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union lll_reduction_core_t:
+            LLLReduction[Z_NR[mpz_t], FP_NR[double]] *mpz_double
+            LLLReduction[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            LLLReduction[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
+
+    IF HAVE_QD:
+        ctypedef union bkz_auto_abort_core_t:
+            BKZAutoAbort[FP_NR[double]] *mpz_double
+            BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
+            BKZAutoAbort[FP_NR[dd_real]] *mpz_dd
+            BKZAutoAbort[FP_NR[qd_real]] *mpz_qd
+            BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union bkz_auto_abort_core_t:
+            BKZAutoAbort[FP_NR[double]] *mpz_double
+            BKZAutoAbort[FP_NR[dpe_t]] *mpz_dpe
+            BKZAutoAbort[FP_NR[mpfr_t]] *mpz_mpfr
+
+    IF HAVE_QD:
+        ctypedef union bkz_reduction_core_t:
+            BKZReduction[FP_NR[double]] *mpz_double
+            BKZReduction[FP_NR[dpe_t]] *mpz_dpe
+            BKZReduction[FP_NR[dd_real]] *mpz_dd
+            BKZReduction[FP_NR[qd_real]] *mpz_qd
+            BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
+    ELSE:
+        ctypedef union bkz_reduction_core_t:
+            BKZReduction[FP_NR[double]] *mpz_double
+            BKZReduction[FP_NR[dpe_t]] *mpz_dpe
+            BKZReduction[FP_NR[mpfr_t]] *mpz_mpfr
+
+    IF HAVE_QD:
+        ctypedef union fast_evaluator_core_t:
+            FastEvaluator[FP_NR[double]] *double
+            FastEvaluator[FP_NR[dpe_t]] *dpe
+            FastEvaluator[FP_NR[dd_real]] *dd
+            FastEvaluator[FP_NR[qd_real]] *qd
+            FastEvaluator[FP_NR[mpfr_t]] *mpfr
+    ELSE:
+        ctypedef union fast_evaluator_core_t:
+            FastEvaluator[FP_NR[double]] *double
+            FastEvaluator[FP_NR[dpe_t]] *dpe
+            FastEvaluator[FP_NR[mpfr_t]] *mpfr
+
+    IF HAVE_QD:
+        ctypedef union enumeration_core_t:
+            Enumeration[FP_NR[double]] *double
+            Enumeration[FP_NR[dpe_t]] *dpe
+            Enumeration[FP_NR[dd_real]] *dd
+            Enumeration[FP_NR[qd_real]] *qd
+            Enumeration[FP_NR[mpfr_t]] *mpfr
+    ELSE:
+        ctypedef union enumeration_core_t:
+            Enumeration[FP_NR[double]] *double
+            Enumeration[FP_NR[dpe_t]] *dpe
+            Enumeration[FP_NR[mpfr_t]] *mpfr
+
+    IF HAVE_QD:
+        # we cannot use a union because of non-trivial constructors
+        ctypedef struct vector_fp_nr_t:
+            vector[FP_NR[double]] double
+            vector[FP_NR[dpe_t]] dpe
+            vector[FP_NR[dd_real]] dd
+            vector[FP_NR[qd_real]] qd
+            vector[FP_NR[mpfr_t]] mpfr
+    ELSE:
+        ctypedef struct vector_fp_nr_t:
+            vector[FP_NR[double]] double
+            vector[FP_NR[dpe_t]] dpe
+            vector[FP_NR[mpfr_t]] mpfr

--- a/src/fpylll/fplll/gso.pyx
+++ b/src/fpylll/fplll/gso.pyx
@@ -135,8 +135,11 @@ cdef class MatGSO:
             self._type = mpz_double
             self._core.mpz_double = new MatGSO_c[Z_NR[mpz_t],FP_NR[double]](b[0], u[0], u_inv_t[0], flags)
         elif float_type_ == FT_LONG_DOUBLE:
-            self._type = mpz_ld
-            self._core.mpz_ld = new MatGSO_c[Z_NR[mpz_t],FP_NR[longdouble]](b[0], u[0], u_inv_t[0], flags)
+            IF HAVE_LONG_DOUBLE:
+                self._type = mpz_ld
+                self._core.mpz_ld = new MatGSO_c[Z_NR[mpz_t],FP_NR[longdouble]](b[0], u[0], u_inv_t[0], flags)
+            ELSE:
+                raise ValueError("Float type '%s' not understood." % float_type)
         elif float_type_ == FT_DPE:
             self._type = mpz_dpe
             self._core.mpz_dpe = new MatGSO_c[Z_NR[mpz_t],FP_NR[dpe_t]](b[0], u[0], u_inv_t[0], flags)
@@ -161,8 +164,9 @@ cdef class MatGSO:
     def __dealloc__(self):
         if self._type == mpz_double:
             del self._core.mpz_double
-        if self._type == mpz_ld:
-            del self._core.mpz_ld
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                del self._core.mpz_ld
         if self._type == mpz_dpe:
             del self._core.mpz_dpe
         IF HAVE_QD:
@@ -196,8 +200,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return "double"
-        if self._type == mpz_ld:
-            return "long double"
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return "long double"
         if self._type == mpz_dpe:
             return "dpe"
         IF HAVE_QD:
@@ -222,8 +227,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return self._core.mpz_double.d
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.d
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.d
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.d
         IF HAVE_QD:
@@ -254,8 +260,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.enable_int_gram)
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.enable_int_gram)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.enable_int_gram)
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.enable_int_gram)
         IF HAVE_QD:
@@ -286,8 +293,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.enable_row_expo)
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.enable_row_expo)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.enable_row_expo)
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.enable_row_expo)
         IF HAVE_QD:
@@ -320,8 +328,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.enable_transform)
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.enable_transform)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.enable_transform)
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.enable_transform)
         IF HAVE_QD:
@@ -354,8 +363,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.enable_inverse_transform)
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.enable_inverse_transform)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.enable_inverse_transform)
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.enable_inverse_transform)
         IF HAVE_QD:
@@ -386,8 +396,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.row_op_force_long)
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.row_op_force_long)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.row_op_force_long)
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.row_op_force_long)
         IF HAVE_QD:
@@ -411,8 +422,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return self._core.mpz_double.row_op_begin(first, last)
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.row_op_begin(first, last)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.row_op_begin(first, last)
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.row_op_begin(first, last)
         IF HAVE_QD:
@@ -437,8 +449,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return self._core.mpz_double.row_op_end(first, last)
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.row_op_end(first, last)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.row_op_end(first, last)
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.row_op_end(first, last)
         IF HAVE_QD:
@@ -478,8 +491,9 @@ cdef class MatGSO:
         # TODO: don't just return doubles
         if self._type == mpz_double:
             return self._core.mpz_double.get_gram(t.double, i, j).get_d()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.get_gram(t.ld, i, j).get_d()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.get_gram(t.ld, i, j).get_d()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.get_gram(t.dpe, i, j).get_d()
         IF HAVE_QD:
@@ -514,8 +528,9 @@ cdef class MatGSO:
         # TODO: don't just return doubles
         if self._type == mpz_double:
             return self._core.mpz_double.get_r(t.double, i, j).get_d()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.get_r(t.ld, i, j).get_d()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.get_r(t.ld, i, j).get_d()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.get_r(t.dpe, i, j).get_d()
         IF HAVE_QD:
@@ -548,9 +563,10 @@ cdef class MatGSO:
         if self._type == mpz_double:
             r = self._core.mpz_double.get_r_exp(i, j, expo).get_data()
             return r, expo
-        if self._type == mpz_ld:
-            r = self._core.mpz_ld.get_r_exp(i, j, expo).get_d()
-            return r, expo
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                r = self._core.mpz_ld.get_r_exp(i, j, expo).get_d()
+                return r, expo
         if self._type == mpz_dpe:
             r = self._core.mpz_dpe.get_r_exp(i, j, expo).get_d()
             return r, expo
@@ -582,8 +598,9 @@ cdef class MatGSO:
         # TODO: don't just return doubles
         if self._type == mpz_double:
             return self._core.mpz_double.get_mu(t.double, i, j).get_d()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.get_mu(t.ld, i, j).get_d()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.get_mu(t.ld, i, j).get_d()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.get_mu(t.dpe, i, j).get_d()
         IF HAVE_QD:
@@ -616,9 +633,10 @@ cdef class MatGSO:
         if self._type == mpz_double:
             r = self._core.mpz_double.get_mu_exp(i, j, expo).get_data()
             return r, expo
-        if self._type == mpz_ld:
-            r = self._core.mpz_ld.get_mu_exp(i, j, expo).get_d()
-            return r, expo
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                r = self._core.mpz_ld.get_mu_exp(i, j, expo).get_d()
+                return r, expo
         if self._type == mpz_dpe:
             r = self._core.mpz_dpe.get_mu_exp(i, j, expo).get_d()
             return r, expo
@@ -645,10 +663,11 @@ cdef class MatGSO:
             with nogil:
                 r = self._core.mpz_double.update_gso()
             return bool(r)
-        if self._type == mpz_ld:
-            with nogil:
-                r = self._core.mpz_ld.update_gso()
-            return bool(r)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                with nogil:
+                    r = self._core.mpz_ld.update_gso()
+                return bool(r)
         if self._type == mpz_dpe:
             with nogil:
                 r = self._core.mpz_dpe.update_gso()
@@ -680,8 +699,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return bool(self._core.mpz_double.update_gso_row(i, last_j))
-        if self._type == mpz_ld:
-            return bool(self._core.mpz_ld.update_gso_row(i, last_j))
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return bool(self._core.mpz_ld.update_gso_row(i, last_j))
         if self._type == mpz_dpe:
             return bool(self._core.mpz_dpe.update_gso_row(i, last_j))
         IF HAVE_QD:
@@ -701,8 +721,9 @@ cdef class MatGSO:
         """
         if self._type == mpz_double:
             return self._core.mpz_double.discover_all_rows()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.discover_all_rows()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.discover_all_rows()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.discover_all_rows()
         IF HAVE_QD:
@@ -727,8 +748,9 @@ cdef class MatGSO:
         preprocess_indices(old_r, new_r, self.d, self.d)
         if self._type == mpz_double:
             return self._core.mpz_double.move_row(old_r, new_r)
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.move_row(old_r, new_r)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.move_row(old_r, new_r)
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.move_row(old_r, new_r)
         IF HAVE_QD:
@@ -798,9 +820,10 @@ cdef class MatGSO:
         if self._type == mpz_double:
             x_.double = float(x)
             return self._core.mpz_double.row_addmul(i, j, x_.double)
-        if self._type == mpz_ld:
-            x_.ld = float(x)
-            return self._core.mpz_ld.row_addmul(i, j, x_.ld)
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                x_.ld = float(x)
+                return self._core.mpz_ld.row_addmul(i, j, x_.ld)
         if self._type == mpz_dpe:
             x_.dpe = float(x)
             return self._core.mpz_dpe.row_addmul(i, j, x_.dpe)
@@ -828,8 +851,9 @@ cdef class MatGSO:
 
         if self._type == mpz_double:
             return self._core.mpz_double.create_row()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.create_row()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.create_row()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.create_row()
         IF HAVE_QD:
@@ -852,8 +876,9 @@ cdef class MatGSO:
 
         if self._type == mpz_double:
             return self._core.mpz_double.remove_last_row()
-        if self._type == mpz_ld:
-            return self._core.mpz_ld.remove_last_row()
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                return self._core.mpz_ld.remove_last_row()
         if self._type == mpz_dpe:
             return self._core.mpz_dpe.remove_last_row()
         IF HAVE_QD:
@@ -884,11 +909,12 @@ cdef class MatGSO:
             r = self._core.mpz_double.get_current_slope(start_row, stop_row)
             sig_off()
             return r
-        if self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.get_current_slope(start_row, stop_row)
-            sig_off()
-            return r
+        IF HAVE_LONG_DOUBLE:
+            if self._type == mpz_ld:
+                sig_on()
+                r = self._core.mpz_ld.get_current_slope(start_row, stop_row)
+                sig_off()
+                return r
         if self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.get_current_slope(start_row, stop_row)
@@ -927,11 +953,6 @@ cdef class MatGSO:
             r = self._core.mpz_double.get_root_det(start_row, stop_row).get_d()
             sig_off()
             return r
-        elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.get_root_det(start_row, stop_row).get_d()
-            sig_off()
-            return r
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.get_root_det(start_row, stop_row).get_d()
@@ -943,6 +964,12 @@ cdef class MatGSO:
             sig_off()
             return r
         else:
+            IF HAVE_LONG_DOUBLE:
+                if self._type == mpz_ld:
+                    sig_on()
+                    r = self._core.mpz_ld.get_root_det(start_row, stop_row).get_d()
+                    sig_off()
+                    return r
             IF HAVE_QD:
                 if self._type == mpz_dd:
                     sig_on()
@@ -970,11 +997,6 @@ cdef class MatGSO:
             r = self._core.mpz_double.get_log_det(start_row, stop_row).get_d()
             sig_off()
             return r
-        elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.get_log_det(start_row, stop_row).get_d()
-            sig_off()
-            return r
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.get_log_det(start_row, stop_row).get_d()
@@ -986,6 +1008,12 @@ cdef class MatGSO:
             sig_off()
             return r
         else:
+            IF HAVE_LONG_DOUBLE:
+                if self._type == mpz_ld:
+                    sig_on()
+                    r = self._core.mpz_ld.get_log_det(start_row, stop_row).get_d()
+                    sig_off()
+                    return r
             IF HAVE_QD:
                 if self._type == mpz_dd:
                     sig_on()
@@ -1014,11 +1042,6 @@ cdef class MatGSO:
             r = self._core.mpz_double.get_slide_potential(start_row, stop_row, block_size).get_d()
             sig_off()
             return r
-        elif self._type == mpz_ld:
-            sig_on()
-            r = self._core.mpz_ld.get_slide_potential(start_row, stop_row, block_size).get_d()
-            sig_off()
-            return r
         elif self._type == mpz_dpe:
             sig_on()
             r = self._core.mpz_dpe.get_slide_potential(start_row, stop_row, block_size).get_d()
@@ -1030,6 +1053,12 @@ cdef class MatGSO:
             sig_off()
             return r
         else:
+            IF HAVE_LONG_DOUBLE:
+                if self._type == mpz_ld:
+                    sig_on()
+                    r = self._core.mpz_ld.get_slide_potential(start_row, stop_row, block_size).get_d()
+                    sig_off()
+                    return r
             IF HAVE_QD:
                 if self._type == mpz_dd:
                     sig_on()

--- a/src/fpylll/numpy.pyx
+++ b/src/fpylll/numpy.pyx
@@ -28,8 +28,9 @@ def _dump_mu(ndarray[double, ndim=2, mode="c"] mu not None, MatGSO M, int kappa,
      """
     if M._type == mpz_double:
         return M._core.mpz_double.dump_mu_d(&mu[0,0], kappa, block_size)
-    if M._type == mpz_ld:
-        return M._core.mpz_ld.dump_mu_d(&mu[0,0], kappa, block_size)
+    IF HAVE_LONG_DOUBLE:
+        if M._type == mpz_ld:
+            return M._core.mpz_ld.dump_mu_d(&mu[0,0], kappa, block_size)
     if M._type == mpz_dpe:
         return M._core.mpz_dpe.dump_mu_d(&mu[0,0], kappa, block_size)
     IF HAVE_QD:
@@ -70,8 +71,9 @@ def _dump_r(ndarray[double, ndim=1, mode="c"] r not None, MatGSO M, int kappa, i
 
     if M._type == mpz_double:
         return M._core.mpz_double.dump_r_d(&r[0], kappa, block_size)
-    if M._type == mpz_ld:
-        return M._core.mpz_ld.dump_r_d(&r[0], kappa, block_size)
+    IF HAVE_LONG_DOUBLE:
+        if M._type == mpz_ld:
+            return M._core.mpz_ld.dump_r_d(&r[0], kappa, block_size)
     if M._type == mpz_dpe:
         return M._core.mpz_dpe.dump_r_d(&r[0], kappa, block_size)
     IF HAVE_QD:

--- a/src/fpylll/util.pyx
+++ b/src/fpylll/util.pyx
@@ -136,8 +136,9 @@ def get_precision(float_type="mpfr"):
 
     if float_type_ == FT_DOUBLE:
         return FP_NR[double].get_prec()
-    if float_type_ == FT_LONG_DOUBLE:
-        return FP_NR[longdouble].get_prec()
+    IF HAVE_LONG_DOUBLE:
+        if float_type_ == FT_LONG_DOUBLE:
+            return FP_NR[longdouble].get_prec()
     if float_type_ == FT_DPE:
         return FP_NR[dpe_t].get_prec()
     IF HAVE_QD:


### PR DESCRIPTION
Currently long double is disabled explicitly on Cygwin where it is known not to be available (more specifically long double functions are just aliases for the normal double versions).

This does keep the `mpz_ld` member of the `fplll_type_t` enum, even without `HAVE_LONG_DOUBLE`, which was convenient in a few places, but this could be removed with a little restructuring.

I've confirmed all the tests pass for me with this patch.  Fixes #40 