### PR TITLE
correct spelling errors as detected by Lintian (controversial)

### DIFF
--- a/src/fpylll/fplll/bkz.pyx
+++ b/src/fpylll/fplll/bkz.pyx
@@ -96,7 +96,7 @@ cdef class BKZAutoAbort:
         for `max_no_dec` iterations.
 
         :param scale: target decrease
-        :param int max_no_dec: number of rounds we allow to be stuck
+        :param int max_no_dec: number of rounds allowed to be stuck
         """
         if self._type == mpz_double:
             return self._core.mpz_double.test_abort(scale, max_no_dec)


### PR DESCRIPTION
Description: source typo: controversial
 Correct spelling error as reported by lintian in some binaries; meant to silence lintian.
Origin: vendor, Debian
Bug: https://github.com/fplll/fpylll/issues/43
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2016-10-22
