### PR TITLE
ascii only, for python3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ We recommend `virtualenv <https://virtualenv.readthedocs.org/>`__ for isolating 
 
    We indicate active virtualenvs by the prefix ``(fpylll)``.
 
-2. Install the required libraries – `GMP <https://gmplib.org>`__ or `MPIR <http://mpir.org>`__ and `MPFR <http://www.mpfr.org>`__  – if not available already. You may also want to install `QD <http://crd-legacy.lbl.gov/~dhbailey/mpdist/>`__.
+2. Install the required libraries - `GMP <https://gmplib.org>`__ or `MPIR <http://mpir.org>`__ and `MPFR <http://www.mpfr.org>`__  - if not available already. You may also want to install `QD <http://crd-legacy.lbl.gov/~dhbailey/mpdist/>`__.
 
 3. Install fplll:
 
@@ -164,7 +164,7 @@ in the ``deactivate`` function in the ``activate`` script.
 Multicore Support
 -----------------
 
-**fpylll** supports parallelisation on multiple cores. For all C++ support to drop the `GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`_ is enabled, allowing the use of threads to parallelise. Note, however, that because fplll’s enumeration is not thread safe, we using `locks <https://docs.python.org/2/library/threading.html#lock-objects>`_ to enforce only one thread calls it at any one point. Also, **fpylll** does not actually drop the GIL in all calls to C++ functions yet. In many scenarios using `multiprocessing <https://docs.python.org/2/library/multiprocessing.html>`_, which sidesteps the GIL and thread safety issues by using processes instead of threads, will be the better choice.
+**fpylll** supports parallelisation on multiple cores. For all C++ support to drop the `GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`_ is enabled, allowing the use of threads to parallelise. Note, however, that because fplll's enumeration is not thread safe, we using `locks <https://docs.python.org/2/library/threading.html#lock-objects>`_ to enforce only one thread calls it at any one point. Also, **fpylll** does not actually drop the GIL in all calls to C++ functions yet. In many scenarios using `multiprocessing <https://docs.python.org/2/library/multiprocessing.html>`_, which sidesteps the GIL and thread safety issues by using processes instead of threads, will be the better choice.
 
 The example below calls ``LLL.reduction`` on 128 matrices of dimension 30 on four worker processes.
 
@@ -216,6 +216,6 @@ The following people have contributed to **fpylll**
 - Leo Ducas
 - Omer Katz
 
-We copied a decent bit of code over from Sage, mostly from it’s fpLLL interface.
+We copied a decent bit of code over from Sage, mostly from it's fpLLL interface.
 
 **fpylll** is licensed under the GPLv2+.  


### PR DESCRIPTION
remove 4 non-ascii characters, that broke the build with python3 in sage