### PR TITLE
cimport cysignals instead of using includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     url="https://github.com/fplll/fpylll",
     version='0.2.4dev',
     ext_modules=Cython.Build.cythonize(extensions,
-                                       include_path=["src"] + sys.path,
+                                       include_path=["src"],
                                        build_dir=cythonize_dir,
                                        compiler_directives={'embedsignature': True}),
     package_dir={"": "src"},

--- a/src/fpylll/config.pyx
+++ b/src/fpylll/config.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 
 from fplll.fplll cimport default_strategy as default_strategy_c

--- a/src/fpylll/fplll/bkz.pyx
+++ b/src/fpylll/fplll/bkz.pyx
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 """
 Block Korkine Zolotarev algorithm.
 
 ..  moduleauthor:: Martin R.  Albrecht <martinralbrecht+fpylll@googlemail.com>
 """
+
+from cysignals.signals cimport sig_on, sig_off
 
 IF HAVE_QD:
     from decl cimport mpz_dd, mpz_qd

--- a/src/fpylll/fplll/bkz_param.pyx
+++ b/src/fpylll/fplll/bkz_param.pyx
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 """
 Parameters for Block Korkine Zolotarev algorithm.
 
 ..  moduleauthor:: Martin R.  Albrecht <martinralbrecht+fpylll@googlemail.com>
 """
+
+from cysignals.signals cimport sig_on, sig_off
+
 from fplll cimport BKZParam as BKZParam_c
 from fplll cimport BKZ_MAX_LOOPS, BKZ_MAX_TIME, BKZ_DUMP_GSO, BKZ_DEFAULT
 from fplll cimport BKZ_VERBOSE, BKZ_NO_LLL, BKZ_BOUNDED_LLL, BKZ_GH_BND, BKZ_AUTO_ABORT

--- a/src/fpylll/fplll/enumeration.pyx
+++ b/src/fpylll/fplll/enumeration.pyx
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 from cython.operator cimport dereference as deref, preincrement as inc
 
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp cimport bool
+from cysignals.signals cimport sig_on, sig_off
+
 from gso cimport MatGSO
 from fplll cimport EvaluatorStrategy as EvaluatorStrategy_c
 from fplll cimport EVALSTRATEGY_BEST_N_SOLUTIONS

--- a/src/fpylll/fplll/gso.pyx
+++ b/src/fpylll/fplll/gso.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 """
 Elementary basis operations, Gram matrix and Gram-Schmidt orthogonalization.
@@ -19,6 +18,7 @@ It holds that: `B = R × Q = (μ × D) × (D^{-1} × B^*)` where `Q` is orthonor
 triangular.
 """
 
+from cysignals.signals cimport sig_on, sig_off
 
 from decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr, fp_nr_t
 from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
@@ -38,7 +38,6 @@ IF HAVE_QD:
     from fpylll.qd.qd cimport dd_real, qd_real
     from decl cimport mpz_dd, mpz_qd
     from fplll cimport FT_DD, FT_QD
-
 
 class MatGSORowOpContext(object):
     """

--- a/src/fpylll/fplll/integer_matrix.pyx
+++ b/src/fpylll/fplll/integer_matrix.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 """
 Integer matrices.
@@ -8,9 +7,9 @@ Integer matrices.
 .. moduleauthor:: Martin R. Albrecht <martinralbrecht+fpylll@googlemail.com>
 """
 
-include "cysignals/signals.pxi"
-
 from cpython cimport PyIndex_Check
+from cysignals.signals cimport sig_on, sig_off
+
 from fplll cimport Matrix, MatrixRow, sqr_norm, Z_NR
 from fpylll.util cimport preprocess_indices
 from fpylll.io cimport assign_Z_NR_mpz, assign_mpz, mpz_get_python
@@ -20,7 +19,6 @@ from math import log10, ceil, sqrt, floor
 
 from fpylll.gmp.pylong cimport mpz_get_pyintlong
 from fpylll.gmp.mpz cimport mpz_init, mpz_mod, mpz_fdiv_q_ui, mpz_clear, mpz_cmp, mpz_sub, mpz_set
-
 
 cdef class IntegerMatrixRow:
     """

--- a/src/fpylll/fplll/lll.pyx
+++ b/src/fpylll/fplll/lll.pyx
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
+
+from cysignals.signals cimport sig_on, sig_off
 
 from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t

--- a/src/fpylll/fplll/pruner.pyx
+++ b/src/fpylll/fplll/pruner.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 """
 Pruner
 
@@ -21,6 +20,7 @@ Pruner
 """
 from libcpp.vector cimport vector
 from math import log, exp
+from cysignals.signals cimport sig_on, sig_off
 
 from decl cimport mpz_double, mpz_dpe, mpz_mpfr, fp_nr_t, mpz_t, dpe_t, mpfr_t
 from bkz_param cimport Pruning

--- a/src/fpylll/fplll/svpcvp.pyx
+++ b/src/fpylll/fplll/svpcvp.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 """
 Shortest and Closest Vectors.
@@ -9,6 +8,7 @@ Shortest and Closest Vectors.
 """
 
 import threading
+from cysignals.signals cimport sig_on, sig_off
 
 from libcpp.vector cimport vector
 from fpylll.gmp.mpz cimport mpz_t

--- a/src/fpylll/fplll/wrapper.pyx
+++ b/src/fpylll/fplll/wrapper.pyx
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
+
+from cysignals.signals cimport sig_on, sig_off
 
 from fplll cimport Matrix, Z_NR, mpz_t
 from fplll cimport LLL_DEF_ETA, LLL_DEF_DELTA, LLL_DEFAULT

--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
-
 from cpython.int cimport PyInt_AS_LONG
 from fpylll.gmp.mpz cimport mpz_init, mpz_clear, mpz_set
 from fpylll.gmp.pylong cimport mpz_get_pyintlong, mpz_set_pylong

--- a/src/fpylll/numpy.pyx
+++ b/src/fpylll/numpy.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 
 from fpylll.fplll.gso cimport MatGSO

--- a/src/fpylll/util.pyx
+++ b/src/fpylll/util.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-include "cysignals/signals.pxi"
 
 
 from fpylll.fplll.decl cimport mpz_double, mpz_ld, mpz_dpe, mpz_mpfr, fp_nr_t


### PR DESCRIPTION
In recent versions of cysignals, the `.pxi` files are deprecated. Instead, regular `cimports` should be used. This avoids the need for https://github.com/cython/cython/pull/483 and goes along with the Cython philosophy that one should prefer `cimport` over `include`.