### PR TITLE
Update integer_matrix.pyx

### DIFF
--- a/src/fpylll/fplll/integer_matrix.pyx
+++ b/src/fpylll/fplll/integer_matrix.pyx
@@ -425,7 +425,7 @@ cdef class IntegerMatrix:
         except TypeError:
             for i in range(m):
                 for j in range(n):
-                    A[i][j] = A[i][j]
+                    A[i][j] = self[i, j]
         return A
 
     def __dealloc__(self):


### PR DESCRIPTION
Fix bug on converting IntegerMatrix to matrix object which only supports m[i][j] assignment.