### PR TITLE
Be more robust to different types of errors when importing Sage

### DIFF
--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -9,7 +9,7 @@ from gmp.mpz cimport mpz_t, mpz_set_si, mpz_set
 try:
     from sage.all import ZZ
     have_sage = True
-except ImportError:
+except Exception:
     have_sage = False
 
 cdef int assign_Z_NR_mpz(Z_NR[mpz_t]& t, value) except -1:


### PR DESCRIPTION
On Debian, running `python -c 'import sage.all'` fails with:
~~~~
[..]
  File "/usr/lib/python2.7/dist-packages/sage/interfaces/maxima.py", line 539, in __init__
    raise RuntimeError('You must get the file local/bin/sage-maxima.lisp')
RuntimeError: You must get the file local/bin/sage-maxima.lisp
~~~~
The underlying reason being that `sage-env` logic is not run, so `SAGE_LOCAL` et.al. are not defined. This causes `python -c "import fpylll"` to fail with the same error, when `sagemath` is installed.

This commit fixes this, by making `fpylll` more robust to these sorts of errors - it will fall back to the `have_sage = False` behaviour when the import fails but for a reason other than `ImportError`.

(OTOH, if `python -c 'import sage.all'` is *supposed* to work, then this is also a bug in Sage - the auto-detection logic in `sage-env` should be moved to the `sage.env` python module instead. See also [Debian bug 870698 message 20](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=870698#20).)