### PR TITLE
Use official version of Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -307,3 +307,11 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# Monkey-patch inspect with Cython support
+# See http://opendreamkit.org/2017/06/09/CythonSphinx/
+def isfunction(obj):
+    return hasattr(type(obj), "__code__")
+
+import inspect
+inspect.isfunction = isfunction

--- a/suggestions.txt
+++ b/suggestions.txt
@@ -1,3 +1,3 @@
 ipython
-git+https://github.com/jdemeyer/sphinx
 numpy
+Sphinx>=1.6


### PR DESCRIPTION
Instead of relying on a custom patched Sphinx, use a released version of Sphinx.