### PR TITLE
Fix some broken declarations and imports when not HAVE_LONG_DOUBLE

### DIFF
--- a/src/fpylll/fplll/decl.pxd
+++ b/src/fpylll/fplll/decl.pxd
@@ -396,9 +396,9 @@ ELSE:
             Enumeration[Z_NR[long], FP_NR[mpfr_t]] *long_mpfr
     ELSE:
         ctypedef union enumeration_core_t:
-            Enumeration[FP_NR[d_t]] *d
-            Enumeration[FP_NR[dpe_t]] *dpe
-            Enumeration[FP_NR[mpfr_t]] *mpfr
+            Enumeration[Z_NR[mpz_t], FP_NR[d_t]] *mpz_d
+            Enumeration[Z_NR[mpz_t], FP_NR[dpe_t]] *mpz_dpe
+            Enumeration[Z_NR[mpz_t], FP_NR[mpfr_t]] *mpz_mpfr
             Enumeration[Z_NR[long], FP_NR[d_t]] *long_d
             Enumeration[Z_NR[long], FP_NR[dpe_t]] *long_dpe
             Enumeration[Z_NR[long], FP_NR[mpfr_t]] *long_mpfr

--- a/src/fpylll/fplll/enumeration.pyx
+++ b/src/fpylll/fplll/enumeration.pyx
@@ -24,10 +24,13 @@ from fplll cimport dpe_t
 from fpylll.mpfr.mpfr cimport mpfr_t
 from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t
 from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
-from decl cimport d_t, ld_t
+from decl cimport d_t
 from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
 
 from fplll cimport multimap
+
+IF HAVE_LONG_DOUBLE:
+    from decl cimport ld_t
 
 IF HAVE_QD:
     from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t

--- a/src/fpylll/fplll/gso.pyx
+++ b/src/fpylll/fplll/gso.pyx
@@ -22,7 +22,7 @@ from cysignals.signals cimport sig_on, sig_off
 
 from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t, zz_mat_core_t
 from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
-from decl cimport d_t, ld_t
+from decl cimport d_t
 from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
 from fplll cimport ZT_LONG, ZT_MPZ, IntType
 from fplll cimport GSO_DEFAULT
@@ -36,6 +36,9 @@ from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t
 from fpylll.util cimport preprocess_indices, check_float_type
 from integer_matrix cimport IntegerMatrix
+
+IF HAVE_LONG_DOUBLE:
+    from decl cimport ld_t
 
 IF HAVE_QD:
     from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t

--- a/src/fpylll/fplll/lll.pyx
+++ b/src/fpylll/fplll/lll.pyx
@@ -31,9 +31,12 @@ from fplll cimport FloatType
 from fpylll.util cimport check_float_type, check_delta, check_eta, check_precision
 from fpylll.util import ReductionError
 
-from decl cimport d_t, ld_t
+from decl cimport d_t
 from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr
 from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
+
+IF HAVE_LONG_DOUBLE:
+    from decl cimport ld_t
 
 IF HAVE_QD:
     from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
@@ -66,7 +69,8 @@ cdef class LLLReduction:
         check_eta(eta)
 
         cdef MatGSO_c[Z_NR[mpz_t], FP_NR[d_t]]  *m_mpz_double
-        cdef MatGSO_c[Z_NR[mpz_t], FP_NR[ld_t]] *m_mpz_ld
+        IF HAVE_LONG_DOUBLE:
+            cdef MatGSO_c[Z_NR[mpz_t], FP_NR[ld_t]] *m_mpz_ld
         cdef MatGSO_c[Z_NR[mpz_t], FP_NR[dpe_t]] *m_mpz_dpe
         IF HAVE_QD:
             cdef MatGSO_c[Z_NR[mpz_t], FP_NR[dd_t]] *m_mpz_dd
@@ -74,7 +78,8 @@ cdef class LLLReduction:
         cdef MatGSO_c[Z_NR[mpz_t], FP_NR[mpfr_t]]  *m_mpz_mpfr
 
         cdef MatGSO_c[Z_NR[long], FP_NR[d_t]]  *m_long_double
-        cdef MatGSO_c[Z_NR[long], FP_NR[ld_t]] *m_long_ld
+        IF HAVE_LONG_DOUBLE:
+            cdef MatGSO_c[Z_NR[long], FP_NR[ld_t]] *m_long_ld
         cdef MatGSO_c[Z_NR[long], FP_NR[dpe_t]] *m_long_dpe
         IF HAVE_QD:
             cdef MatGSO_c[Z_NR[long], FP_NR[dd_t]] *m_long_dd

--- a/src/fpylll/fplll/pruner.pyx
+++ b/src/fpylll/fplll/pruner.pyx
@@ -28,8 +28,8 @@ from cysignals.signals cimport sig_on, sig_off
 from cython.operator cimport dereference as deref, preincrement as inc
 
 from decl cimport fp_nr_t, mpz_t, dpe_t, mpfr_t
-from decl cimport nr_d, nr_dpe, nr_mpfr, pruner_core_t, d_t, ld_t
-from fplll cimport FT_DOUBLE, FT_DPE, FT_MPFR, FloatType
+from decl cimport nr_d, nr_dpe, nr_mpfr, pruner_core_t, d_t
+from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
 from fplll cimport PRUNER_METRIC_PROBABILITY_OF_SHORTEST, PRUNER_METRIC_EXPECTED_SOLUTIONS
 from fplll cimport FP_NR, Z_NR
 from fplll cimport MatGSO as MatGSO_c
@@ -45,12 +45,9 @@ from fpylll.util import adjust_radius_to_gh_bound, precision, get_precision
 from fpylll.util cimport check_float_type, check_precision, check_pruner_metric
 
 IF HAVE_LONG_DOUBLE:
-    from fplll cimport FT_LONG_DOUBLE
-    from decl cimport gso_mpz_ld
-    from decl cimport nr_ld
+    from decl cimport nr_ld, ld_t
 
 IF HAVE_QD:
-    from decl cimport gso_mpz_dd, gso_mpz_qd
     from decl cimport nr_dd, nr_qd, dd_t, qd_t
     from fplll cimport FT_DD, FT_QD
 


### PR DESCRIPTION
I feel like there's got to be a way to more cleanly manage imports for optionally defined types as in the `HAVE_LONG_DOUBLE` and `HAVE_QD` cases.  I'll have to think about that more in the meantime.