### PR TITLE
Add additional configurations to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ language: python
 python:
   - "2.7"
   - "3.5"
+matrix:
+  include:
+    - env: HAVE_QD=no
+    - env: HAVE_LONG_DOUBLE=no
+    - env: HAVE_NUMPY=no
+    - env:
+        - HAVE_QD=no
+        - HAVE_LONG_DOUBLE=no
 
 cache: pip
 

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,6 @@ class build_ext(_build_ext, object):
     # CONFIG VARIABLES
 
     cythonize_dir = "build"
-    include_dirs = None
-    library_dirs = None
-    cxxflags = None
     fplll = None
     other = None
     def_varnames = ['HAVE_QD', 'HAVE_LONG_DOUBLE', 'HAVE_NUMPY']
@@ -67,30 +64,24 @@ class build_ext(_build_ext, object):
 
         def_vars = self._generate_config_pxi()
 
-        if self.include_dirs is None:
-            self.include_dirs = [os.path.join(sys.prefix, "include")]
-
-        if self.library_dirs is None:
-            self.library_dirs = [os.path.join(sys.exec_prefix, "lib")]
-
-        if self.cxxflags is None:
-            flags = os.environ.get("CXXFLAGS", "").split()
-            self.cxxflags = [flag for flag in flags if flag]
+        include_dirs = [os.path.join(sys.prefix, 'include')]
+        library_dirs = [os.path.join(sys.exec_prefix, "lib")]
+        cxxflags = list(filter(None, os.environ.get("CXXFLAGS", "").split()))
 
         if self.fplll is None:
-            self.fplll = {"include_dirs": self.include_dirs,
-                          "library_dirs": self.library_dirs,
+            self.fplll = {"include_dirs": include_dirs,
+                          "library_dirs": library_dirs,
                           "language": "c++",
                           "libraries": ["gmp", "mpfr", "fplll"],
-                          "extra_compile_args": ["-std=c++11"] + self.cxxflags,
+                          "extra_compile_args": ["-std=c++11"] + cxxflags,
                           "extra_link_args": ["-std=c++11"]}
 
             if def_vars['HAVE_QD']:
                 self.fplll['libraries'].append('qd')
 
         if self.other is None:
-            self.other = {"include_dirs": self.include_dirs,
-                          "library_dirs": self.library_dirs,
+            self.other = {"include_dirs": include_dirs,
+                          "library_dirs": library_dirs,
                           "libraries": ["gmp"]}
 
         if "READTHEDOCS" in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ except ImportError:
 
 from os import path
 from ast import parse
+from distutils.command.build_ext import build_ext as _build_ext
 from distutils.core import setup
-from distutils.extension import Extension
+from distutils.extension import Extension as _Extension
 import Cython.Build
 
 from copy import copy
@@ -30,109 +31,172 @@ try:
 except NameError:
     FileNotFoundError = OSError  # Python 2 workaround
 
-
-# CONFIG VARIABLES
 
-cythonize_dir = "build"
+class Extension(_Extension, object):
+    """
+    distutils.extension.Extension subclass supporting additional
+    keywords:
 
-include_dirs = [os.path.join(sys.prefix, "include")]
-library_dirs = [os.path.join(sys.exec_prefix, "lib")]
+        * fplll: compile and link with flags from fplll as defined below in
+          build_ext.fplll below
+        * other: flags for compiling and linking other extension modules
+          (without fplll flags) as defined below in build_ext.other
+    """
 
-cxxflags = [flag for flag in os.environ.get("CXXFLAGS", "").split(" ") if flag]
+    def __init__(self, name, sources, **kwargs):
+        self.fplll = kwargs.pop('fplll', False)
+        self.other = kwargs.pop('other', False)
+        super(Extension, self).__init__(name, sources, **kwargs)
 
-fplll = {"include_dirs": include_dirs,
-         "library_dirs": library_dirs,
-         "language": "c++",
-         "libraries": ["gmp", "mpfr", "fplll"],
-         "extra_compile_args": ["-std=c++11"] + cxxflags,
-         "extra_link_args": ["-std=c++11"]}
 
-other = {"include_dirs": include_dirs,
-         "library_dirs": library_dirs,
-         "libraries": ["gmp"]}
+class build_ext(_build_ext, object):
+    
+    # CONFIG VARIABLES
 
-if "READTHEDOCS" in os.environ:
-    # ReadTheDocs uses fplll from Conda, which was built with the old
-    # C++ ABI.
-    fplll["extra_compile_args"].append("-D_GLIBCXX_USE_CXX11_ABI=0")
+    cythonize_dir = "build"
+    include_dirs = None
+    library_dirs = None
+    cxxflags = None
+    fplll = None
+    other = None
+    def_varnames = ['HAVE_QD', 'HAVE_LONG_DOUBLE', 'HAVE_NUMPY']
+    config_pxi_path = os.path.join(".", "src", "fpylll", "config.pxi")
 
-config_pxi = []
+    def finalize_options(self):
+        super(build_ext, self).finalize_options()
 
-
-# QD
-have_qd = False
+        def_vars = self._generate_config_pxi()
 
-try:
-    libs = subprocess.check_output(["pkg-config", "fplll", "--libs"])
-    if b"-lqd" in libs:
-        have_qd = True
-except (subprocess.CalledProcessError, FileNotFoundError):
-    pass
+        if self.include_dirs is None:
+            self.include_dirs = [os.path.join(sys.prefix, "include")]
 
-if have_qd:
-    fplll["libraries"].append("qd")
-    config_pxi.append("DEF HAVE_QD=True")
-else:
-    config_pxi.append("DEF HAVE_QD=False")
+        if self.library_dirs is None:
+            self.library_dirs = [os.path.join(sys.exec_prefix, "lib")]
 
-
-# NUMPY
+        if self.cxxflags is None:
+            flags = os.environ.get("CXXFLAGS", "").split()
+            self.cxxflags = [flag for flag in flags if flag]
 
-try:
-    import numpy
-    have_numpy = True
-except ImportError:
-    have_numpy = False
+        if self.fplll is None:
+            self.fplll = {"include_dirs": self.include_dirs,
+                          "library_dirs": self.library_dirs,
+                          "language": "c++",
+                          "libraries": ["gmp", "mpfr", "fplll"],
+                          "extra_compile_args": ["-std=c++11"] + self.cxxflags,
+                          "extra_link_args": ["-std=c++11"]}
 
-if have_numpy:
-    config_pxi.append("DEF HAVE_NUMPY=True")
-    numpy_args = copy(fplll)
-    numpy_args["include_dirs"].append(numpy.get_include())
-else:
-    config_pxi.append("DEF HAVE_NUMPY=False")
+            if def_vars['HAVE_QD']:
+                self.fplll['libraries'].append('qd')
 
-# Ideally this would check the fplll headers explicitly for the
-# the FPLLL_WITH_LONG_DOUBLE define, but for now it suffices to
-# say that long double support is disabled on Cygwin
-have_long_double = not sys.platform.startswith('cygwin')
-config_pxi.append("DEF HAVE_LONG_DOUBLE={0}".format(have_long_double))
+        if self.other is None:
+            self.other = {"include_dirs": self.include_dirs,
+                          "library_dirs": self.library_dirs,
+                          "libraries": ["gmp"]}
 
-
-# CONFIG.PXI
-config_pxi_path = os.path.join(".", "src", "fpylll", "config.pxi")
-config_pxi = "\n".join(config_pxi) + "\n"
+        if "READTHEDOCS" in os.environ:
+            # ReadTheDocs uses fplll from Conda, which was built with the old
+            # C++ ABI.
+            self.fplll["extra_compile_args"].append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
-try:
-    cur_config_pxi = open(config_pxi_path, "r").read()
-except IOError:
-    cur_config_pxi = ""
+        if def_vars['HAVE_NUMPY']:
+            import numpy
+            numpy_args = copy(self.fplll)
+            numpy_args["include_dirs"].append(numpy.get_include())
+            self.extensions.append(
+                    Extension("fpylll.numpy", ["src/fpylll/numpy.pyx"],
+                              **numpy_args))
 
-if cur_config_pxi != config_pxi:  # check if we need to write
-    with open(config_pxi_path, "w") as fw:
-        fw.write(config_pxi)
+        for ext in self.extensions:
+            if ext.fplll:
+                for key, value in self.fplll.items():
+                    setattr(ext, key, value)
+            elif ext.other:
+                for key, value in self.other.items():
+                    setattr(ext, key, value)
+
+    def run(self):
+        self.extensions = Cython.Build.cythonize(
+                self.extensions,
+                include_path=["src"],
+                build_dir=self.cythonize_dir,
+                compiler_directives={'binding': True, "embedsignature": True})
+        super(build_ext, self).run()
+
+    def _generate_config_pxi(self):
+        def_vars = {}
+        config_pxi = []
+
+        for defvar in self.def_varnames:
+            # We can optionally read values for these variables for the
+            # environment; this is mostly used to force different values for
+            # testing
+            value = os.environ.get(defvar)
+            if value is not None:
+                value = value.lower() in ['1', 'true', 'yes']
+            else:
+                value = getattr(self, '_get_' + defvar.lower())()
+
+            config_pxi.append('DEF {0}={1}'.format(defvar, value))
+            def_vars[defvar] = value
+
+        config_pxi = "\n".join(config_pxi) + "\n"
+
+        try:
+            cur_config_pxi = open(self.config_pxi_path, "r").read()
+        except IOError:
+            cur_config_pxi = ""
+
+        if cur_config_pxi != config_pxi:  # check if we need to write
+            with open(self.config_pxi_path, "w") as fw:
+                fw.write(config_pxi)
+
+        return def_vars
+
+    def _get_have_qd(self):
+        try:
+            libs = subprocess.check_output(["pkg-config", "fplll", "--libs"])
+            if b"-lqd" in libs:
+                return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+        return False
+
+    def _get_have_numpy(self):
+        try:
+            import numpy
+            return True
+        except ImportError:
+            pass
+
+        return False
+
+    def _get_have_long_double(self):
+        # Ideally this would check the fplll headers explicitly for the
+        # the FPLLL_WITH_LONG_DOUBLE define, but for now it suffices to
+        # say that long double support is disabled on Cygwin
+        return not sys.platform.startswith('cygwin')
+
 
 
 # EXTENSIONS
 
 extensions = [
-    Extension("fpylll.gmp.pylong", ["src/fpylll/gmp/pylong.pyx"], **other),
-    Extension("fpylll.fplll.integer_matrix", ["src/fpylll/fplll/integer_matrix.pyx"], **fplll),
-    Extension("fpylll.fplll.gso", ["src/fpylll/fplll/gso.pyx"], **fplll),
-    Extension("fpylll.fplll.lll", ["src/fpylll/fplll/lll.pyx"], **fplll),
-    Extension("fpylll.fplll.wrapper", ["src/fpylll/fplll/wrapper.pyx"], **fplll),
-    Extension("fpylll.fplll.bkz_param", ["src/fpylll/fplll/bkz_param.pyx"], **fplll),
-    Extension("fpylll.fplll.bkz", ["src/fpylll/fplll/bkz.pyx"], **fplll),
-    Extension("fpylll.fplll.enumeration", ["src/fpylll/fplll/enumeration.pyx"], **fplll),
-    Extension("fpylll.fplll.svpcvp", ["src/fpylll/fplll/svpcvp.pyx"], **fplll),
-    Extension("fpylll.fplll.pruner", ["src/fpylll/fplll/pruner.pyx"], **fplll),
-    Extension("fpylll.fplll.sieve_gauss", ["src/fpylll/fplll/sieve_gauss.pyx"], **fplll),
-    Extension("fpylll.util", ["src/fpylll/util.pyx"], **fplll),
-    Extension("fpylll.io", ["src/fpylll/io.pyx"], **fplll),
-    Extension("fpylll.config", ["src/fpylll/config.pyx"], **fplll),
+    Extension("fpylll.gmp.pylong", ["src/fpylll/gmp/pylong.pyx"], other=True),
+    Extension("fpylll.fplll.integer_matrix", ["src/fpylll/fplll/integer_matrix.pyx"], fplll=True),
+    Extension("fpylll.fplll.gso", ["src/fpylll/fplll/gso.pyx"], fplll=True),
+    Extension("fpylll.fplll.lll", ["src/fpylll/fplll/lll.pyx"], fplll=True),
+    Extension("fpylll.fplll.wrapper", ["src/fpylll/fplll/wrapper.pyx"], fplll=True),
+    Extension("fpylll.fplll.bkz_param", ["src/fpylll/fplll/bkz_param.pyx"], fplll=True),
+    Extension("fpylll.fplll.bkz", ["src/fpylll/fplll/bkz.pyx"], fplll=True),
+    Extension("fpylll.fplll.enumeration", ["src/fpylll/fplll/enumeration.pyx"], fplll=True),
+    Extension("fpylll.fplll.svpcvp", ["src/fpylll/fplll/svpcvp.pyx"], fplll=True),
+    Extension("fpylll.fplll.pruner", ["src/fpylll/fplll/pruner.pyx"], fplll=True),
+    Extension("fpylll.fplll.sieve_gauss", ["src/fpylll/fplll/sieve_gauss.pyx"], fplll=True),
+    Extension("fpylll.util", ["src/fpylll/util.pyx"], fplll=True),
+    Extension("fpylll.io", ["src/fpylll/io.pyx"], fplll=True),
+    Extension("fpylll.config", ["src/fpylll/config.pyx"], fplll=True),
 ]
-
-if have_numpy:
-    extensions.append(Extension("fpylll.numpy", ["src/fpylll/numpy.pyx"], **numpy_args))
 
 
 # VERSION
@@ -150,12 +214,10 @@ setup(
     author_email="fplll-devel@googlegroups.com",
     url="https://github.com/fplll/fpylll",
     version=__version__,
-    ext_modules=Cython.Build.cythonize(extensions,
-                                       include_path=["src"],
-                                       build_dir=cythonize_dir,
-                                       compiler_directives={'binding': True, "embedsignature": True}),
+    ext_modules=extensions,
     package_dir={"": "src"},
     packages=["fpylll", "fpylll.gmp", "fpylll.fplll", "fpylll.algorithms", "fpylll.tools"],
     license='GNU General Public License, version 2 or later',
     long_description=open('README.rst').read(),
+    cmdclass={'build_ext': build_ext}
 )


### PR DESCRIPTION
Building off of #106, this adds four new configurations that are built and tested on Travis (in this case all using Python 2.7 for now): `HAVE_LONG_DOUBLE=False`, `HAVE_QD=False`, `HAVE_NUMPY=False`, and `HAVE_LONG_DOUBLE = HAVE_QD = False`.

This should cover most branches in the Cython code impacted by these compile-time variables, if not all.

As you'll see, Travis finds a few test failures in these cases.