### PR TITLE
Correctly use relative imports

### DIFF
--- a/src/fpylll/config.pyx
+++ b/src/fpylll/config.pyx
@@ -2,8 +2,8 @@
 include "fpylll/config.pxi"
 
 
-from fplll.fplll cimport default_strategy as default_strategy_c
-from fplll.fplll cimport default_strategy_path as default_strategy_path_c
+from .fplll.fplll cimport default_strategy as default_strategy_c
+from .fplll.fplll cimport default_strategy_path as default_strategy_path_c
 
 IF HAVE_LONG_DOUBLE:
     have_long_double = True

--- a/src/fpylll/fplll/bkz.pxd
+++ b/src/fpylll/fplll/bkz.pxd
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from decl cimport bkz_auto_abort_core_t, fplll_gso_type_t
-from decl cimport bkz_reduction_core_t
-from gso cimport MatGSO
-from bkz_param cimport BKZParam
-from lll cimport LLLReduction
+from .decl cimport bkz_auto_abort_core_t, fplll_gso_type_t
+from .decl cimport bkz_reduction_core_t
+from .gso cimport MatGSO
+from .bkz_param cimport BKZParam
+from .lll cimport LLLReduction
 
 cdef class BKZAutoAbort:
     cdef fplll_gso_type_t _type

--- a/src/fpylll/fplll/bkz.pyx
+++ b/src/fpylll/fplll/bkz.pyx
@@ -10,34 +10,33 @@ include "fpylll/config.pxi"
 from cysignals.signals cimport sig_on, sig_off
 
 IF HAVE_QD:
-    from decl cimport gso_mpz_dd, gso_mpz_qd
-    from decl cimport gso_long_dd, gso_long_qd
+    from .decl cimport gso_mpz_dd, gso_mpz_qd
+    from .decl cimport gso_long_dd, gso_long_qd
     from fpylll.qd.qd cimport dd_real, qd_real
 
-from bkz_param cimport BKZParam
-from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, vector_fp_nr_t, fp_nr_t
-from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
-from fplll cimport BKZAutoAbort as BKZAutoAbort_c
-from fplll cimport BKZReduction as BKZReduction_c
-from fplll cimport BKZ_MAX_LOOPS, BKZ_MAX_TIME, BKZ_DUMP_GSO, BKZ_DEFAULT
-from fplll cimport BKZ_VERBOSE, BKZ_NO_LLL, BKZ_BOUNDED_LLL, BKZ_GH_BND, BKZ_AUTO_ABORT
-from fplll cimport BKZ_DEF_AUTO_ABORT_SCALE, BKZ_DEF_AUTO_ABORT_MAX_NO_DEC
-from fplll cimport BKZ_DEF_GH_FACTOR, BKZ_DEF_MIN_SUCCESS_PROBABILITY
-from fplll cimport BKZ_DEF_RERANDOMIZATION_DENSITY
-from fplll cimport BKZ_SD_VARIANT, BKZ_SLD_RED
+from .decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, vector_fp_nr_t, fp_nr_t
+from .decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
+from .fplll cimport BKZAutoAbort as BKZAutoAbort_c
+from .fplll cimport BKZReduction as BKZReduction_c
+from .fplll cimport BKZ_MAX_LOOPS, BKZ_MAX_TIME, BKZ_DUMP_GSO, BKZ_DEFAULT
+from .fplll cimport BKZ_VERBOSE, BKZ_NO_LLL, BKZ_BOUNDED_LLL, BKZ_GH_BND, BKZ_AUTO_ABORT
+from .fplll cimport BKZ_DEF_AUTO_ABORT_SCALE, BKZ_DEF_AUTO_ABORT_MAX_NO_DEC
+from .fplll cimport BKZ_DEF_GH_FACTOR, BKZ_DEF_MIN_SUCCESS_PROBABILITY
+from .fplll cimport BKZ_DEF_RERANDOMIZATION_DENSITY
+from .fplll cimport BKZ_SD_VARIANT, BKZ_SLD_RED
 
-from fplll cimport FP_NR, Z_NR
-from fplll cimport FloatType
-from fplll cimport RED_BKZ_LOOPS_LIMIT, RED_BKZ_TIME_LIMIT
-from fplll cimport bkz_reduction as bkz_reduction_c
-from fplll cimport dpe_t
-from fplll cimport get_red_status_str
-from fplll cimport ZT_MPZ
+from .fplll cimport FP_NR, Z_NR
+from .fplll cimport FloatType
+from .fplll cimport RED_BKZ_LOOPS_LIMIT, RED_BKZ_TIME_LIMIT
+from .fplll cimport bkz_reduction as bkz_reduction_c
+from .fplll cimport dpe_t
+from .fplll cimport get_red_status_str
+from .fplll cimport ZT_MPZ
 from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t
 from fpylll.util cimport check_delta, check_precision, check_float_type
 from fpylll.util import ReductionError
-from integer_matrix cimport IntegerMatrix
+from .integer_matrix cimport IntegerMatrix
 from fpylll.config import default_strategy, default_strategy_path
 
 cdef class BKZAutoAbort:

--- a/src/fpylll/fplll/bkz_param.pxd
+++ b/src/fpylll/fplll/bkz_param.pxd
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from libcpp.vector cimport vector
-from decl cimport bkz_auto_abort_core_t, fplll_gso_type_t
-from gso cimport MatGSO
-from fplll cimport BKZParam as BKZParam_c
-from fplll cimport PruningParams as PruningParams_c
-from fplll cimport Strategy as Strategy_c
-from fplll cimport PrunerMetric
+from .decl cimport bkz_auto_abort_core_t, fplll_gso_type_t
+from .gso cimport MatGSO
+from .fplll cimport BKZParam as BKZParam_c
+from .fplll cimport PruningParams as PruningParams_c
+from .fplll cimport Strategy as Strategy_c
+from .fplll cimport PrunerMetric
 
 cdef class Strategy:
     cdef Strategy_c _core

--- a/src/fpylll/fplll/bkz_param.pyx
+++ b/src/fpylll/fplll/bkz_param.pyx
@@ -9,24 +9,24 @@ include "fpylll/config.pxi"
 
 from cysignals.signals cimport sig_on, sig_off
 
-from fplll cimport BKZParam as BKZParam_c
-from fplll cimport BKZ_MAX_LOOPS, BKZ_MAX_TIME, BKZ_DUMP_GSO, BKZ_DEFAULT
-from fplll cimport BKZ_VERBOSE, BKZ_NO_LLL, BKZ_BOUNDED_LLL, BKZ_GH_BND, BKZ_AUTO_ABORT
-from fplll cimport BKZ_DEF_AUTO_ABORT_SCALE, BKZ_DEF_AUTO_ABORT_MAX_NO_DEC
-from fplll cimport BKZ_DEF_GH_FACTOR, BKZ_DEF_MIN_SUCCESS_PROBABILITY
-from fplll cimport BKZ_DEF_RERANDOMIZATION_DENSITY
-from fplll cimport PRUNER_METRIC_PROBABILITY_OF_SHORTEST
-from fplll cimport PRUNER_METRIC_EXPECTED_SOLUTIONS
-from fplll cimport LLL_DEF_DELTA
-from fplll cimport PruningParams as PruningParams_c
-from fplll cimport Strategy as Strategy_c
-from fplll cimport load_strategies_json as load_strategies_json_c
-from fplll cimport strategy_full_path
+from .fplll cimport BKZParam as BKZParam_c
+from .fplll cimport BKZ_MAX_LOOPS, BKZ_MAX_TIME, BKZ_DUMP_GSO, BKZ_DEFAULT
+from .fplll cimport BKZ_VERBOSE, BKZ_NO_LLL, BKZ_BOUNDED_LLL, BKZ_GH_BND, BKZ_AUTO_ABORT
+from .fplll cimport BKZ_DEF_AUTO_ABORT_SCALE, BKZ_DEF_AUTO_ABORT_MAX_NO_DEC
+from .fplll cimport BKZ_DEF_GH_FACTOR, BKZ_DEF_MIN_SUCCESS_PROBABILITY
+from .fplll cimport BKZ_DEF_RERANDOMIZATION_DENSITY
+from .fplll cimport PRUNER_METRIC_PROBABILITY_OF_SHORTEST
+from .fplll cimport PRUNER_METRIC_EXPECTED_SOLUTIONS
+from .fplll cimport LLL_DEF_DELTA
+from .fplll cimport PruningParams as PruningParams_c
+from .fplll cimport Strategy as Strategy_c
+from .fplll cimport load_strategies_json as load_strategies_json_c
+from .fplll cimport strategy_full_path
 
 from fpylll.util cimport check_delta, check_pruner_metric
 from cython.operator cimport dereference as deref, preincrement as inc
 
-from pruner cimport PruningParams
+from .pruner cimport PruningParams
 
 from collections import OrderedDict
 import json

--- a/src/fpylll/fplll/decl.pxd
+++ b/src/fpylll/fplll/decl.pxd
@@ -13,11 +13,11 @@ from fpylll.mpfr.mpfr cimport mpfr_t
 IF HAVE_QD:
     from fpylll.qd.qd cimport dd_real, qd_real
 
-from fplll cimport dpe_t
-from fplll cimport Z_NR, FP_NR
-from fplll cimport ZZ_mat, MatGSO, LLLReduction, BKZAutoAbort, BKZReduction, Enumeration
-from fplll cimport GaussSieve
-from fplll cimport FastEvaluator, FastErrorBoundedEvaluator, Pruner
+from .fplll cimport dpe_t
+from .fplll cimport Z_NR, FP_NR
+from .fplll cimport ZZ_mat, MatGSO, LLLReduction, BKZAutoAbort, BKZReduction, Enumeration
+from .fplll cimport GaussSieve
+from .fplll cimport FastEvaluator, FastErrorBoundedEvaluator, Pruner
 
 from libcpp.vector cimport vector
 

--- a/src/fpylll/fplll/enumeration.pxd
+++ b/src/fpylll/fplll/enumeration.pxd
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from decl cimport enumeration_core_t, fast_evaluator_core_t, fplll_gso_type_t
-from gso cimport MatGSO
+from .decl cimport enumeration_core_t, fast_evaluator_core_t, fplll_gso_type_t
+from .gso cimport MatGSO
 
 cdef class Enumeration:
     cdef readonly MatGSO M

--- a/src/fpylll/fplll/enumeration.pyx
+++ b/src/fpylll/fplll/enumeration.pyx
@@ -8,33 +8,32 @@ from libcpp.pair cimport pair
 from libcpp cimport bool
 from cysignals.signals cimport sig_on, sig_off
 
-from gso cimport MatGSO
-from fplll cimport EvaluatorStrategy as EvaluatorStrategy_c
-from fplll cimport EVALSTRATEGY_BEST_N_SOLUTIONS
-from fplll cimport EVALSTRATEGY_FIRST_N_SOLUTIONS
-from fplll cimport EVALSTRATEGY_OPPORTUNISTIC_N_SOLUTIONS
-from fplll cimport Enumeration as Enumeration_c
-from fplll cimport FastEvaluator as FastEvaluator_c
-from fplll cimport FastErrorBoundedEvaluator as FastErrorBoundedEvaluator_c
-from fplll cimport MatGSO as MatGSO_c
-from fplll cimport Z_NR, FP_NR, mpz_t
-from fplll cimport EVALMODE_SV
+from .fplll cimport EvaluatorStrategy as EvaluatorStrategy_c
+from .fplll cimport EVALSTRATEGY_BEST_N_SOLUTIONS
+from .fplll cimport EVALSTRATEGY_FIRST_N_SOLUTIONS
+from .fplll cimport EVALSTRATEGY_OPPORTUNISTIC_N_SOLUTIONS
+from .fplll cimport Enumeration as Enumeration_c
+from .fplll cimport FastEvaluator as FastEvaluator_c
+from .fplll cimport FastErrorBoundedEvaluator as FastErrorBoundedEvaluator_c
+from .fplll cimport MatGSO as MatGSO_c
+from .fplll cimport Z_NR, FP_NR, mpz_t
+from .fplll cimport EVALMODE_SV
 
-from fplll cimport dpe_t
+from .fplll cimport dpe_t
 from fpylll.mpfr.mpfr cimport mpfr_t
-from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t
-from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
-from decl cimport d_t
-from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
+from .decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t
+from .decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
+from .decl cimport d_t
+from .fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
 
-from fplll cimport multimap
+from .fplll cimport multimap
 
 IF HAVE_LONG_DOUBLE:
-    from decl cimport ld_t
+    from .decl cimport ld_t
 
 IF HAVE_QD:
-    from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
-    from fplll cimport FT_DD, FT_QD
+    from .decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
+    from .fplll cimport FT_DD, FT_QD
 
 class EnumerationError(Exception):
     pass

--- a/src/fpylll/fplll/gso.pxd
+++ b/src/fpylll/fplll/gso.pxd
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from integer_matrix cimport IntegerMatrix
-from decl cimport mat_gso_core_t, fplll_gso_type_t
+from .integer_matrix cimport IntegerMatrix
+from .decl cimport mat_gso_core_t, fplll_gso_type_t
 
 cdef class MatGSO:
     cdef fplll_gso_type_t _type

--- a/src/fpylll/fplll/gso.pyx
+++ b/src/fpylll/fplll/gso.pyx
@@ -20,29 +20,29 @@ include "fpylll/config.pxi"
 
 from cysignals.signals cimport sig_on, sig_off
 
-from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t, zz_mat_core_t
-from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
-from decl cimport d_t
-from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
-from fplll cimport ZT_LONG, ZT_MPZ, IntType
-from fplll cimport GSO_DEFAULT
-from fplll cimport GSO_INT_GRAM
-from fplll cimport GSO_OP_FORCE_LONG
-from fplll cimport GSO_ROW_EXPO
-from fplll cimport MatGSO as MatGSO_c, Z_NR, FP_NR, Matrix
-from fplll cimport dpe_t
-from fplll cimport get_current_slope
+from .decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr, fp_nr_t, zz_mat_core_t
+from .decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
+from .decl cimport d_t
+from .fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
+from .fplll cimport ZT_LONG, ZT_MPZ, IntType
+from .fplll cimport GSO_DEFAULT
+from .fplll cimport GSO_INT_GRAM
+from .fplll cimport GSO_OP_FORCE_LONG
+from .fplll cimport GSO_ROW_EXPO
+from .fplll cimport MatGSO as MatGSO_c, Z_NR, FP_NR, Matrix
+from .fplll cimport dpe_t
+from .fplll cimport get_current_slope
 from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t
 from fpylll.util cimport preprocess_indices, check_float_type
-from integer_matrix cimport IntegerMatrix
+from .integer_matrix cimport IntegerMatrix
 
 IF HAVE_LONG_DOUBLE:
-    from decl cimport ld_t
+    from .decl cimport ld_t
 
 IF HAVE_QD:
-    from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
-    from fplll cimport FT_DD, FT_QD
+    from .decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
+    from .fplll cimport FT_DD, FT_QD
 
 class MatGSORowOpContext(object):
     """

--- a/src/fpylll/fplll/integer_matrix.pxd
+++ b/src/fpylll/fplll/integer_matrix.pxd
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from fpylll.gmp.types cimport mpz_t
-from fplll cimport IntType
-from decl cimport zz_mat_core_t
+from .fplll cimport IntType
+from .decl cimport zz_mat_core_t
 
 cdef class IntegerMatrix:
     cdef IntType _type

--- a/src/fpylll/fplll/integer_matrix.pyx
+++ b/src/fpylll/fplll/integer_matrix.pyx
@@ -11,16 +11,16 @@ include "fpylll/config.pxi"
 from cpython cimport PyIndex_Check
 from cysignals.signals cimport sig_on, sig_off
 
-from fplll cimport Matrix, MatrixRow, Z_NR
+from .fplll cimport Matrix, MatrixRow, Z_NR
 from fpylll.util cimport preprocess_indices, check_int_type
 from fpylll.io cimport assign_Z_NR_mpz, assign_mpz, mpz_get_python
 
-from fplll cimport IntType, ZT_MPZ, ZT_LONG, ZZ_mat
+from .fplll cimport IntType, ZT_MPZ, ZT_LONG, ZZ_mat
 
 import re
 from math import log10, ceil, sqrt, floor
 
-from decl cimport z_long, z_mpz
+from .decl cimport z_long, z_mpz
 from fpylll.gmp.pylong cimport mpz_get_pyintlong
 from fpylll.gmp.mpz cimport mpz_init, mpz_mod, mpz_fdiv_q_ui, mpz_clear, mpz_cmp, mpz_sub, mpz_set, mpz_set_si, mpz_get_si
 

--- a/src/fpylll/fplll/lll.pxd
+++ b/src/fpylll/fplll/lll.pxd
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from gso cimport MatGSO
-from decl cimport lll_reduction_core_t, fplll_gso_type_t
+from .gso cimport MatGSO
+from .decl cimport lll_reduction_core_t, fplll_gso_type_t
 
 cdef class LLLReduction:
 

--- a/src/fpylll/fplll/lll.pyx
+++ b/src/fpylll/fplll/lll.pyx
@@ -6,42 +6,42 @@ from cysignals.signals cimport sig_on, sig_off
 
 from fpylll.gmp.mpz cimport mpz_t
 from fpylll.mpfr.mpfr cimport mpfr_t
-from integer_matrix cimport IntegerMatrix
+from .integer_matrix cimport IntegerMatrix
 
-from fplll cimport LLL_VERBOSE
-from fplll cimport LLL_EARLY_RED
-from fplll cimport LLL_SIEGEL
-from fplll cimport LLL_DEFAULT
+from .fplll cimport LLL_VERBOSE
+from .fplll cimport LLL_EARLY_RED
+from .fplll cimport LLL_SIEGEL
+from .fplll cimport LLL_DEFAULT
 
-from fplll cimport LLLMethod, LLL_DEF_ETA, LLL_DEF_DELTA
-from fplll cimport LM_WRAPPER, LM_PROVED, LM_HEURISTIC, LM_FAST
-from fplll cimport FT_DEFAULT, FT_DOUBLE, FT_LONG_DOUBLE, FT_DD, FT_QD
-from fplll cimport ZT_MPZ
+from .fplll cimport LLLMethod, LLL_DEF_ETA, LLL_DEF_DELTA
+from .fplll cimport LM_WRAPPER, LM_PROVED, LM_HEURISTIC, LM_FAST
+from .fplll cimport FT_DEFAULT, FT_DOUBLE, FT_LONG_DOUBLE, FT_DD, FT_QD
+from .fplll cimport ZT_MPZ
 
-from fplll cimport dpe_t
-from fplll cimport Z_NR, FP_NR
-from fplll cimport lll_reduction as lll_reduction_c
-from fplll cimport RED_SUCCESS
-from fplll cimport MatGSO as MatGSO_c
-from fplll cimport LLLReduction as LLLReduction_c
-from fplll cimport get_red_status_str
-from fplll cimport is_lll_reduced
-from fplll cimport FloatType
+from .fplll cimport dpe_t
+from .fplll cimport Z_NR, FP_NR
+from .fplll cimport lll_reduction as lll_reduction_c
+from .fplll cimport RED_SUCCESS
+from .fplll cimport MatGSO as MatGSO_c
+from .fplll cimport LLLReduction as LLLReduction_c
+from .fplll cimport get_red_status_str
+from .fplll cimport is_lll_reduced
+from .fplll cimport FloatType
 
 from fpylll.util cimport check_float_type, check_delta, check_eta, check_precision
 from fpylll.util import ReductionError
 
-from decl cimport d_t
-from decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr
-from decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
+from .decl cimport d_t
+from .decl cimport gso_mpz_d, gso_mpz_ld, gso_mpz_dpe, gso_mpz_mpfr
+from .decl cimport gso_long_d, gso_long_ld, gso_long_dpe, gso_long_mpfr
 
 IF HAVE_LONG_DOUBLE:
-    from decl cimport ld_t
+    from .decl cimport ld_t
 
 IF HAVE_QD:
-    from decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
+    from .decl cimport gso_mpz_dd, gso_mpz_qd, gso_long_dd, gso_long_qd, dd_t, qd_t
 
-from wrapper import Wrapper
+from .wrapper import Wrapper
 
 cdef class LLLReduction:
     def __init__(self, MatGSO M,

--- a/src/fpylll/fplll/pruner.pxd
+++ b/src/fpylll/fplll/pruner.pxd
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from integer_matrix cimport IntegerMatrix
-from decl cimport pruner_core_t, fplll_nr_type_t
-from fplll cimport PruningParams as PruningParams_c
+from .integer_matrix cimport IntegerMatrix
+from .decl cimport pruner_core_t, fplll_nr_type_t
+from .fplll cimport PruningParams as PruningParams_c
 
 cdef class PruningParams:
     cdef PruningParams_c _core

--- a/src/fpylll/fplll/pruner.pyx
+++ b/src/fpylll/fplll/pruner.pyx
@@ -27,31 +27,31 @@ from math import log, exp
 from cysignals.signals cimport sig_on, sig_off
 from cython.operator cimport dereference as deref, preincrement as inc
 
-from decl cimport fp_nr_t, mpz_t, dpe_t, mpfr_t
-from decl cimport nr_d, nr_dpe, nr_mpfr, pruner_core_t, d_t
-from fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
-from fplll cimport PRUNER_METRIC_PROBABILITY_OF_SHORTEST, PRUNER_METRIC_EXPECTED_SOLUTIONS
-from fplll cimport FP_NR, Z_NR
-from fplll cimport MatGSO as MatGSO_c
-from fplll cimport prune as prune_c
-from fplll cimport PruningParams as PruningParams_c
-from fplll cimport Pruner as Pruner_c
-from fplll cimport PrunerMetric
-from fplll cimport svp_probability as svp_probability_c
-from fplll cimport PRUNER_CVP, PRUNER_START_FROM_INPUT, PRUNER_GRADIENT, PRUNER_NELDER_MEAD, PRUNER_VERBOSE
+from .decl cimport fp_nr_t, mpz_t, dpe_t, mpfr_t
+from .decl cimport nr_d, nr_dpe, nr_mpfr, pruner_core_t, d_t
+from .fplll cimport FT_DOUBLE, FT_LONG_DOUBLE, FT_DPE, FT_MPFR, FloatType
+from .fplll cimport PRUNER_METRIC_PROBABILITY_OF_SHORTEST, PRUNER_METRIC_EXPECTED_SOLUTIONS
+from .fplll cimport FP_NR, Z_NR
+from .fplll cimport MatGSO as MatGSO_c
+from .fplll cimport prune as prune_c
+from .fplll cimport PruningParams as PruningParams_c
+from .fplll cimport Pruner as Pruner_c
+from .fplll cimport PrunerMetric
+from .fplll cimport svp_probability as svp_probability_c
+from .fplll cimport PRUNER_CVP, PRUNER_START_FROM_INPUT, PRUNER_GRADIENT, PRUNER_NELDER_MEAD, PRUNER_VERBOSE
 
 
 from fpylll.util import adjust_radius_to_gh_bound, precision, FPLLL
 from fpylll.util cimport check_float_type, check_precision, check_pruner_metric
 
 IF HAVE_LONG_DOUBLE:
-    from decl cimport nr_ld, ld_t
+    from .decl cimport nr_ld, ld_t
 
 IF HAVE_QD:
-    from decl cimport nr_dd, nr_qd, dd_t, qd_t
-    from fplll cimport FT_DD, FT_QD
+    from .decl cimport nr_dd, nr_qd, dd_t, qd_t
+    from .fplll cimport FT_DD, FT_QD
 
-from gso cimport MatGSO
+from .gso cimport MatGSO
 
 
 cdef class PruningParams:

--- a/src/fpylll/fplll/sieve_gauss.pxd
+++ b/src/fpylll/fplll/sieve_gauss.pxd
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from fpylll.gmp.types cimport mpz_t
-from fplll cimport FP_NR, IntType
-from decl cimport gauss_sieve_core_t
+from .fplll cimport FP_NR, IntType
+from .decl cimport gauss_sieve_core_t
 
 cdef class GaussSieve:
     cdef IntType _type

--- a/src/fpylll/fplll/sieve_gauss.pyx
+++ b/src/fpylll/fplll/sieve_gauss.pyx
@@ -23,10 +23,10 @@ Example::
 include "fpylll/config.pxi"
 
 from random import randint
-from fplll cimport NumVect, Z_NR, ZT_MPZ, ZT_LONG
-from fplll cimport GaussSieve as GaussSieve_c
+from .fplll cimport NumVect, Z_NR, ZT_MPZ, ZT_LONG
+from .fplll cimport GaussSieve as GaussSieve_c
 from fpylll.io cimport assign_Z_NR_mpz, mpz_get_python
-from integer_matrix cimport IntegerMatrix
+from .integer_matrix cimport IntegerMatrix
 from cysignals.signals cimport sig_on, sig_off
 
 

--- a/src/fpylll/fplll/svpcvp.pyx
+++ b/src/fpylll/fplll/svpcvp.pyx
@@ -12,21 +12,21 @@ from cysignals.signals cimport sig_on, sig_off
 
 from libcpp.vector cimport vector
 from fpylll.gmp.mpz cimport mpz_t
-from fplll cimport Z_NR, ZT_MPZ
-from fplll cimport SVP_DEFAULT, CVP_DEFAULT
-from fplll cimport SVP_VERBOSE, CVP_VERBOSE
-from fplll cimport SVP_OVERRIDE_BND
-from fplll cimport SVPM_PROVED, SVPM_FAST
-from fplll cimport SVPMethod
-from fplll cimport shortest_vector_pruning
-from fplll cimport shortest_vector as shortest_vector_c
-from fplll cimport closest_vector as closest_vector_c
-from fplll cimport vector_matrix_product
-from lll import lll_reduction
+from .fplll cimport Z_NR, ZT_MPZ
+from .fplll cimport SVP_DEFAULT, CVP_DEFAULT
+from .fplll cimport SVP_VERBOSE, CVP_VERBOSE
+from .fplll cimport SVP_OVERRIDE_BND
+from .fplll cimport SVPM_PROVED, SVPM_FAST
+from .fplll cimport SVPMethod
+from .fplll cimport shortest_vector_pruning
+from .fplll cimport shortest_vector as shortest_vector_c
+from .fplll cimport closest_vector as closest_vector_c
+from .fplll cimport vector_matrix_product
+from .lll import lll_reduction
 from fpylll.io cimport assign_Z_NR_mpz, mpz_get_python
 from fpylll.util import ReductionError
 
-from integer_matrix cimport IntegerMatrix
+from .integer_matrix cimport IntegerMatrix
 
 def shortest_vector(IntegerMatrix B, method=None, int flags=SVP_DEFAULT, pruning=None, run_lll=True, max_aux_sols=0):
     """Return a shortest vector.

--- a/src/fpylll/fplll/wrapper.pxd
+++ b/src/fpylll/fplll/wrapper.pxd
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from fplll cimport Wrapper as Wrapper_c
-from integer_matrix cimport IntegerMatrix
+from .fplll cimport Wrapper as Wrapper_c
+from .integer_matrix cimport IntegerMatrix
 
 cdef class Wrapper:
     cdef Wrapper_c *_core

--- a/src/fpylll/fplll/wrapper.pyx
+++ b/src/fpylll/fplll/wrapper.pyx
@@ -4,9 +4,9 @@ include "fpylll/config.pxi"
 
 from cysignals.signals cimport sig_on, sig_off
 
-from fplll cimport Matrix, Z_NR, mpz_t, ZT_MPZ
-from fplll cimport LLL_DEF_ETA, LLL_DEF_DELTA, LLL_DEFAULT
-from fplll cimport get_red_status_str
+from .fplll cimport Matrix, Z_NR, mpz_t, ZT_MPZ
+from .fplll cimport LLL_DEF_ETA, LLL_DEF_DELTA, LLL_DEFAULT
+from .fplll cimport get_red_status_str
 from fpylll.util import ReductionError
 
 

--- a/src/fpylll/gmp/all.pxd
+++ b/src/fpylll/gmp/all.pxd
@@ -1,6 +1,6 @@
 # copied/adapted from Sage development tree version 6.9
-from types cimport *
-from random cimport *
-from mpz cimport *
-from mpq cimport *
-from pylong cimport *
+from .types cimport *
+from .random cimport *
+from .mpz cimport *
+from .mpq cimport *
+from .pylong cimport *

--- a/src/fpylll/gmp/mpf.pxd
+++ b/src/fpylll/gmp/mpf.pxd
@@ -1,7 +1,7 @@
 # copied/adapted from Sage development tree version 6.9
 # distutils: libraries = gmp
 
-from types cimport *
+from .types cimport *
 
 cdef extern from "gmp.h":
 

--- a/src/fpylll/gmp/mpn.pxd
+++ b/src/fpylll/gmp/mpn.pxd
@@ -1,7 +1,7 @@
 # copied/adapted from Sage development tree version 6.9
 # distutils: libraries = gmp
 
-from types cimport *
+from .types cimport *
 
 cdef extern from "gmp.h":
 

--- a/src/fpylll/gmp/mpq.pxd
+++ b/src/fpylll/gmp/mpq.pxd
@@ -1,7 +1,7 @@
 # copied/adapted from Sage development tree version 6.9
 # distutils: libraries = gmp
 
-from types cimport *
+from .types cimport *
 
 cdef extern from "gmp.h":
 

--- a/src/fpylll/gmp/mpz.pxd
+++ b/src/fpylll/gmp/mpz.pxd
@@ -1,9 +1,9 @@
 # copied/adapted from Sage development tree version 6.9
 # distutils: libraries = gmp
 
-from types cimport *
-from libc.stdio cimport FILE
+from .types cimport *
 
+from libc.stdio cimport FILE
 from libc.stdint cimport intmax_t, uintmax_t
 
 cdef extern from "gmp.h":

--- a/src/fpylll/gmp/pylong.pyx
+++ b/src/fpylll/gmp/pylong.pyx
@@ -28,7 +28,7 @@ AUTHORS:
 
 from cpython.int cimport PyInt_FromLong
 from cpython.long cimport PyLong_CheckExact, PyLong_FromLong
-from mpz cimport *
+from .mpz cimport *
 
 # Unused bits in every PyLong digit
 cdef size_t PyLong_nails = 8*sizeof(digit) - PyLong_SHIFT

--- a/src/fpylll/gmp/random.pxd
+++ b/src/fpylll/gmp/random.pxd
@@ -1,7 +1,7 @@
 # copied/adapted from Sage development tree version 6.9
 # distutils: libraries = gmp
 
-from types cimport *
+from .types cimport *
 
 cdef extern from "gmp.h":
 

--- a/src/fpylll/io.pxd
+++ b/src/fpylll/io.pxd
@@ -1,8 +1,8 @@
 include "fpylll/config.pxi"
 
-from fplll.fplll cimport Z_NR
-from gmp.mpz cimport mpz_t
-from gmp.types cimport mpz_srcptr
+from .fplll.fplll cimport Z_NR
+from .gmp.mpz cimport mpz_t
+from .gmp.types cimport mpz_srcptr
 
 cdef int assign_Z_NR_mpz(Z_NR[mpz_t]& t, value) except -1
 cdef int assign_mpz(mpz_t& t, value) except -1

--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -4,7 +4,7 @@ include "fpylll/config.pxi"
 from cpython.int cimport PyInt_AS_LONG
 from fpylll.gmp.mpz cimport mpz_init, mpz_clear, mpz_set
 from fpylll.gmp.pylong cimport mpz_get_pyintlong, mpz_set_pylong
-from gmp.mpz cimport mpz_t, mpz_set_si, mpz_set
+from .gmp.mpz cimport mpz_t, mpz_set_si, mpz_set
 
 try:
     from sage.all import ZZ

--- a/src/fpylll/util.pxd
+++ b/src/fpylll/util.pxd
@@ -1,7 +1,7 @@
-from gmp.mpz cimport mpz_t
-from fplll.fplll cimport FloatType, Z_NR, PrunerMetric, IntType
-from fplll.fplll cimport BKZParam as BKZParam_c
-from fpylll.fplll.fplll cimport PrunerMetric
+from .gmp.mpz cimport mpz_t
+from .fplll.fplll cimport FloatType, Z_NR, PrunerMetric, IntType
+from .fplll.fplll cimport BKZParam as BKZParam_c
+from .fplll.fplll cimport PrunerMetric
 
 cdef FloatType check_float_type(object float_type)
 cdef IntType check_int_type(object int_type)


### PR DESCRIPTION
Change all relative `import` and `cimport` statements to correctly use relative import syntax.