### PR TITLE
correct spelling errors as detected by Lintian

### DIFF
--- a/src/fpylll/fplll/bkz_param.pyx
+++ b/src/fpylll/fplll/bkz_param.pyx
@@ -435,9 +435,9 @@ cdef class BKZParam:
 
         """
         if not isinstance(what, str):
-            raise TypeError("Only strings are supported as auxilary keys but got %s"%what)
+            raise TypeError("Only strings are supported as auxiliary keys but got %s"%what)
         if not what.startswith("aux"):
-            raise ValueError("Auxilary keys must start with 'aux' but got '%s'"%what)
+            raise ValueError("Auxiliary keys must start with 'aux' but got '%s'"%what)
         self.aux[what] = value
 
     def dict(self, all=True):


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in the binary library; meant
  to silence lintian and eventually to be submitted to the upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2018-01-26