### PR TITLE
dump squared GSO lengths to tracer object at the end of each tour

### DIFF
--- a/src/fpylll/algorithms/bkz.py
+++ b/src/fpylll/algorithms/bkz.py
@@ -85,10 +85,7 @@ class BKZReduction(object):
 
         i = 0
         while True:
-            with tracer.context(
-                    "tour",
-                    i,
-                    dump_gso=params.flags & BKZ.DUMP_GSO):
+            with tracer.context("tour", i, dump_gso=params.flags & BKZ.DUMP_GSO):
                 clean = self.tour(params, min_row, max_row, tracer)
             i += 1
             if clean or params.block_size >= self.A.nrows:

--- a/src/fpylll/algorithms/bkz.py
+++ b/src/fpylll/algorithms/bkz.py
@@ -85,7 +85,10 @@ class BKZReduction(object):
 
         i = 0
         while True:
-            with tracer.context("tour", i):
+            with tracer.context(
+                    "tour",
+                    i,
+                    dump_gso=params.flags & BKZ.DUMP_GSO):
                 clean = self.tour(params, min_row, max_row, tracer)
             i += 1
             if clean or params.block_size >= self.A.nrows:

--- a/src/fpylll/tools/bkz_stats.py
+++ b/src/fpylll/tools/bkz_stats.py
@@ -822,6 +822,9 @@ class BKZTreeTracer(Tracer):
         node.data["cputime"] += time.clock()
         node.data["walltime"] += time.time()
 
+        if kwds.get("dump_gso", False):
+            node.data["r"] = node.data.get("r", []) + [self.instance.M.r()]
+
         if label == "enumeration":
             full = kwds.get("full", True)
             if full:


### PR DESCRIPTION
Allows for GS lengths to be saved in tracer for later inspection. dump_gso_filename still allows for the GSO to be dumped to a file outside of the tracer.