### PR TITLE
Use time.perf_counter() instead of the deprecated time.clock().

### DIFF
--- a/src/fpylll/algorithms/bkz.py
+++ b/src/fpylll/algorithms/bkz.py
@@ -78,7 +78,7 @@ class BKZReduction(object):
         if params.flags & BKZ.AUTO_ABORT:
             auto_abort = BKZ.AutoAbort(self.M, self.A.nrows)
 
-        cputime_start = time.clock()
+        cputime_start = time.perf_counter()
 
         with tracer.context("lll"):
             self.lll_obj()
@@ -94,7 +94,7 @@ class BKZReduction(object):
                 break
             if (params.flags & BKZ.MAX_LOOPS) and i >= params.max_loops:
                 break
-            if (params.flags & BKZ.MAX_TIME) and time.clock() - cputime_start >= params.max_time:
+            if (params.flags & BKZ.MAX_TIME) and time.perf_counter() - cputime_start >= params.max_time:
                 break
 
         tracer.exit()

--- a/src/fpylll/tools/bkz_stats.py
+++ b/src/fpylll/tools/bkz_stats.py
@@ -749,7 +749,7 @@ class TimeTreeTracer(Tracer):
             # we exited the root node
             self.current = self.trace
         node = self.current
-        node.data["cputime"]  = node.data.get("cputime",  0) + Accumulator(-time.clock(), repr="sum", count=False)
+        node.data["cputime"]  = node.data.get("cputime",  0) + Accumulator(-time.perf_counter(), repr="sum", count=False)
         node.data["walltime"] = node.data.get("walltime", 0) + Accumulator(-time.time(),  repr="sum", count=False)
 
     def exit(self, **kwds):
@@ -763,7 +763,7 @@ class TimeTreeTracer(Tracer):
         """
         node = self.current
 
-        node.data["cputime"] += time.clock()
+        node.data["cputime"] += time.perf_counter()
         node.data["walltime"] += time.time()
 
         if self.verbosity and self.verbosity >= self.current.level:
@@ -808,7 +808,7 @@ class BKZTreeTracer(Tracer):
         """
 
         node = self.current
-        node.data["cputime"]  = node.data.get("cputime",  0) + Accumulator(-time.clock(), repr="sum", count=False)
+        node.data["cputime"]  = node.data.get("cputime",  0) + Accumulator(-time.perf_counter(), repr="sum", count=False)
         node.data["walltime"] = node.data.get("walltime", 0) + Accumulator(-time.time(),  repr="sum", count=False)
 
     def exit(self, **kwds):  # noqa, shut up linter about this function being too complex
@@ -819,7 +819,7 @@ class BKZTreeTracer(Tracer):
         node = self.current
         label = node.label
 
-        node.data["cputime"] += time.clock()
+        node.data["cputime"] += time.perf_counter()
         node.data["walltime"] += time.time()
 
         if kwds.get("dump_gso", False):

--- a/tests/test_pruner.py
+++ b/tests/test_pruner.py
@@ -2,7 +2,7 @@
 
 from fpylll import Enumeration, GSO, IntegerMatrix, LLL, Pruning
 from fpylll.util import gaussian_heuristic
-from time import clock
+from time import perf_counter
 
 dim_oh = ((40, 2**22), (41, 2**22), (50, 2**24), (51, 2**24))
 
@@ -30,9 +30,9 @@ def test_pruner():
         print(" \n GREEDY")
         radius = gaussian_heuristic(r) * 1.6
         print("pre-greedy radius %.4e" % radius)
-        tt = clock()
+        tt = perf_counter()
         pruning =Pruning.run(radius, overhead, r, 200, flags=Pruning.ZEALOUS, metric="solutions")
-        print("Time %.4e"%(clock() - tt))
+        print("Time %.4e"%(perf_counter() - tt))
         print("post-greedy radius %.4e" % radius)
         print(pruning)
         print("cost %.4e" % sum(pruning.detailed_cost))
@@ -43,9 +43,9 @@ def test_pruner():
 
         print(" \n GREEDY \n")
         print("pre-greedy radius %.4e" % radius)
-        tt = clock()
+        tt = perf_counter()
         pruning = Pruning.run(radius, overhead, r, 200, flags=Pruning.ZEALOUS, metric="solutions")
-        print("Time %.4e"%(clock() - tt))
+        print("Time %.4e"%(perf_counter() - tt))
         print("post-greedy radius %.4e" % radius)
         print(pruning)
         print("cost %.4e" % sum(pruning.detailed_cost))
@@ -57,9 +57,9 @@ def test_pruner():
         print(" \n GRADIENT \n")
 
         print("radius %.4e" % radius)
-        tt = clock()
+        tt = perf_counter()
         pruning = Pruning.run(radius, overhead, r, 200, flags=Pruning.GRADIENT, metric="solutions")
-        print("Time %.4e"%(clock() - tt))
+        print("Time %.4e"%(perf_counter() - tt))
         print(pruning)
         print("cost %.4e" % sum(pruning.detailed_cost))
         solutions = Enumeration(M, nr_solutions=10000).enumerate(0, n, radius, 0, pruning=pruning.coefficients)
@@ -70,9 +70,9 @@ def test_pruner():
         print(" \n HYBRID \n")
 
         print("radius %.4e" % radius)
-        tt = clock()
+        tt = perf_counter()
         pruning = Pruning.run(radius, overhead, r, 200, flags=Pruning.ZEALOUS, metric="solutions")
-        print("Time %.4e"%(clock() - tt))
+        print("Time %.4e"%(perf_counter() - tt))
         print(pruning)
         print("cost %.4e" % sum(pruning.detailed_cost))
         solutions = Enumeration(M, nr_solutions=10000).enumerate(0, n, radius, 0, pruning=pruning.coefficients)


### PR DESCRIPTION
The function time.clock() was deprecated in python 3.3, and has been removed entirely from the upcoming python 3.8.  See https://docs.python.org/3.8/whatsnew/3.8.html#api-and-feature-removals.  This patch changes time.clock() calls to time.perf_counter() calls.