### PR TITLE
Instructions for upgrading inside of Sage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ The instructions are very similar to the manual ones above.
      $ (sage-sh) python setup.py install
      $ (sage-sh) exit
 
-Done! To verify you are running the latest version of fpylll, run
+7. Verify the upgrade went well:
 
    .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,20 @@ We indicate active virtualenvs by the prefix ``(fpylll)``.
 
    in the ``deactivate`` function in the ``activate`` script.
 
+**Running fpylll**
+
+1. To (re)activate the virtual environment, simply run:
+
+   .. code-block:: bash
+
+    $ source ./activate
+
+2. Start Python:
+
+   .. code-block:: bash
+
+    $ (fpylll) ipython
+
 **Manual update of fpylll and fplll inside Sagemath 9.0+**
 
 The instructions are very similar to the manual ones above.
@@ -225,21 +239,6 @@ The instructions are very similar to the manual ones above.
      $ sage
      sage: import fpylll
      sage: print(fpylll.__version__)
-
-
-**Running fpylll**
-
-1. To (re)activate the virtual environment, simply run:
-
-   .. code-block:: bash
-
-    $ source ./activate
-
-2. Start Python:
-
-   .. code-block:: bash
-
-    $ (fpylll) ipython
 
 
 Multicore Support

--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,62 @@ We indicate active virtualenvs by the prefix ``(fpylll)``.
 
    in the ``deactivate`` function in the ``activate`` script.
 
+**Manual update of fpylll and fplll inside Sagemath 9.0+**
+
+The instructions are very similar to the manual ones above.
+
+1. Activate the sage-sh virtualenv:
+
+   .. code-block:: bash
+
+     $ sage -sh
+
+
+2. Install the required libraries - `GMP <https://gmplib.org>`__ or `MPIR <http://mpir.org>`__ and `MPFR <http://www.mpfr.org>`__  - if not available already. You may also want to install `QD <http://crd-legacy.lbl.gov/~dhbailey/mpdist/>`__.
+
+3. Install fplll:
+
+   .. code-block:: bash
+
+     $ (sage-sh) ./install-dependencies.sh $SAGE_LOCAL
+
+   Some OSX users report that they required ``export CXXFLAGS="-stdlib=libc++ -mmacosx-version-min=10.7"`` and ``export CXX=clang++`` (after installing a recent clang with `brew <https://brew.sh>`__) since the default GCC installed by Apple does not have full C++11 support.
+
+4. Then, execute:
+
+   .. code-block:: bash
+
+     $ (sage-sh) pip3 install Cython
+     $ (sage-sh) pip3 install -r requirements.txt
+
+   to install the required Python packages (see above).
+
+5. If you are so inclined, run:
+
+   .. code-block:: bash
+
+     $ (sage-sh) pip3 install -r suggestions.txt
+
+   to install suggested Python packages as well (optional).
+
+6. Build the Python extension:
+
+   .. code-block:: bash
+
+     $ (sage-sh) export PKG_CONFIG_PATH="$SAGE_LOCAL/lib/pkgconfig:$PKG_CONFIG_PATH"
+     $ (sage-sh) python setup.py build_ext
+     $ (sage-sh) python setup.py install
+     $ (sage-sh) exit
+
+Done! To verify you are running the latest version of fpylll, run
+
+   .. code-block:: bash
+
+     $ sage
+     sage: import fpylll
+     sage: print(fpylll.__version__)
+
+
 **Running fpylll**
 
 1. To (re)activate the virtual environment, simply run:


### PR DESCRIPTION
Not sure how common of an issue this is, but personally I'd love to see a note on this somewhere. 

Probably, it could also be merged with the manual install instructions by adding some python2 vs python3 notes and adding an `export VIRTUAL_ENV=$SAGE_LOCAL` command.