### PR TITLE
SVP & CVP Improvements

### DIFF
--- a/src/fpylll/fplll/svpcvp.pyx
+++ b/src/fpylll/fplll/svpcvp.pyx
@@ -24,6 +24,7 @@ from .fplll cimport shortest_vector_pruning
 from .fplll cimport shortest_vector as shortest_vector_c
 from .fplll cimport closest_vector as closest_vector_c
 from .fplll cimport vector_matrix_product
+from .fplll cimport FPLLL_MAX_ENUM_DIM as MAX_ENUM_DIM
 from .lll import lll_reduction
 from fpylll.io cimport assign_Z_NR_mpz, mpz_get_python
 from fpylll.util import ReductionError
@@ -43,6 +44,9 @@ def shortest_vector(IntegerMatrix B, method="proved", int flags=SVP_DEFAULT, pru
     :rtype:
 
     """
+
+    if B.nrows > MAX_ENUM_DIM:
+        raise NotImplementedError("This build of FPLLL is configured with a maximum enumeration dimension of %d."%MAX_ENUM_DIM)
 
     if B._type != ZT_MPZ:
         raise NotImplementedError("Only integer matrices over GMP integers (mpz_t) are supported.")
@@ -140,6 +144,9 @@ def closest_vector(IntegerMatrix B, target, method="fast", int flags=CVP_DEFAULT
         (-34, 109, 204, 360, -1548)
 
     """
+
+    if B.nrows > MAX_ENUM_DIM:
+        raise NotImplementedError("This build of FPLLL is configured with a maximum enumeration dimension of %d."%MAX_ENUM_DIM)
 
     if B._type != ZT_MPZ:
         raise NotImplementedError("Only integer matrices over GMP integers (mpz_t) are supported.")

--- a/src/fpylll/fplll/svpcvp.pyx
+++ b/src/fpylll/fplll/svpcvp.pyx
@@ -7,6 +7,7 @@ Shortest and Closest Vectors.
 
 include "fpylll/config.pxi"
 
+import warnings
 from cysignals.signals cimport sig_on, sig_off
 
 from libcpp.vector cimport vector
@@ -99,6 +100,10 @@ def shortest_vector(IntegerMatrix B, method="fast", int flags=SVP_DEFAULT, pruni
                 break
             except RuntimeError:
                 pass
+
+    if pruning is True: # it didn't work
+        warnings.warn("Pruning failed, proceeding without it.", RuntimeWarning)
+        pruning = [1]*d
 
     cdef vector[Z_NR[mpz_t]] sol_coord
     cdef vector[Z_NR[mpz_t]] solution

--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 include "fpylll/config.pxi"
-
+
+import sys
+import io
+import os
+
 from cpython.int cimport PyInt_AS_LONG
 from fpylll.gmp.mpz cimport mpz_init, mpz_clear, mpz_set
 from fpylll.gmp.pylong cimport mpz_get_pyintlong, mpz_set_pylong
@@ -51,3 +55,30 @@ cdef object mpz_get_python(mpz_srcptr z):
         return Integer(r)
     else:
         return r
+
+class SuppressStream(object):
+    """
+    Suppress errors (being printed by FPLLL, which are to be expected).
+    """
+
+    def __init__(self, stream=sys.stderr):
+        try:
+            self.orig_stream_fileno = stream.fileno()
+            self.skip = False
+        except io.UnsupportedOperation:
+            self.skip = True
+
+    def __enter__(self):
+        if self.skip:
+            return
+        self.orig_stream_dup = os.dup(self.orig_stream_fileno)
+        self.devnull = open(os.devnull, "w")
+        os.dup2(self.devnull.fileno(), self.orig_stream_fileno)
+
+    def __exit__(self, type, value, traceback):
+        if self.skip:
+            return
+        os.close(self.orig_stream_fileno)
+        os.dup2(self.orig_stream_dup, self.orig_stream_fileno)
+        os.close(self.orig_stream_dup)
+        self.devnull.close()

--- a/tests/test_svp.py
+++ b/tests/test_svp.py
@@ -3,7 +3,7 @@
 from fpylll import GSO, IntegerMatrix, LLL, SVP, Enumeration
 import pytest
 
-dimensions = ((3, 3), (10, 10), (20, 20),)
+dimensions = ((3, 3), (10, 10), (20, 20), (30, 30), (40, 40))
 
 
 def make_integer_matrix(m, n):
@@ -18,13 +18,27 @@ def test_svp():
         A = LLL.reduction(A)
         M = GSO.Mat(A)
         M.update_gso()
-        v0 = SVP.shortest_vector(A)
-
         E = Enumeration(M)
         _, v1 = E.enumerate(0, M.d, M.get_r(0, 0), 0)[0]
         v1 = A.multiply_left(v1)
+        nv1 = sum([v_**2 for v_ in v1])
 
-        assert v0 == v1
+        v0 = SVP.shortest_vector(A)
+        nv0 = sum([v_**2 for v_ in v0])
+
+        assert nv0 == nv1
+
+
+def test_svp_params():
+    params = [{"pruning": False, "preprocess": 2},
+              {"pruning": True, "preprocess": 30},
+              {"method": "proved"},
+              {"max_aux_solutions": 20}]
+
+    for kwds in params:
+        for m, n in dimensions:
+            A = make_integer_matrix(m, n)
+            SVP.shortest_vector(A, **kwds)
 
 
 def test_svp_too_large():

--- a/tests/test_svp.py
+++ b/tests/test_svp.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from fpylll import GSO, IntegerMatrix, LLL, CVP, Enumeration
+from fpylll import GSO, IntegerMatrix, LLL, SVP, Enumeration
 import pytest
 
-dimensions = ((3, 3), (10, 10), (20, 20), (40, 40),)
+dimensions = ((3, 3), (10, 10), (20, 20),)
 
 
 def make_integer_matrix(m, n):
@@ -12,24 +12,22 @@ def make_integer_matrix(m, n):
     return A
 
 
-def test_cvp():
+def test_svp():
     for m, n in dimensions:
         A = make_integer_matrix(m, n)
         A = LLL.reduction(A)
         M = GSO.Mat(A)
         M.update_gso()
-        t = list(make_integer_matrix(n, n)[0])
-        v0 = CVP.closest_vector(A, t)
+        v0 = SVP.shortest_vector(A)
 
         E = Enumeration(M)
-        _, v1 = E.enumerate(0, A.nrows, 2, 40, M.from_canonical(t))[0]
-        v1 = IntegerMatrix.from_iterable(1, A.nrows, map(lambda x: int(round(x)), v1))
-        v1 = tuple((v1*A)[0])
+        _, v1 = E.enumerate(0, M.d, M.get_r(0, 0), 0)[0]
+        v1 = A.multiply_left(v1)
 
         assert v0 == v1
 
 
-def test_cvp_too_large():
+def test_svp_too_large():
     from fpylll.config import max_enum_dim
     m = max_enum_dim + 1
     n = max_enum_dim + 1
@@ -37,6 +35,5 @@ def test_cvp_too_large():
     A = LLL.reduction(A)
     M = GSO.Mat(A)
     M.update_gso()
-    t = list(make_integer_matrix(n, n)[0])
     with pytest.raises(NotImplementedError):
-        CVP.closest_vector(A, t)
+        SVP.shortest_vector(A)


### PR DESCRIPTION
- `SVP.shortest_vector` now mostly does the right thing, i.e. it is no longer the wrong thing to call
- both bomb out with a helpful error message when the dimensions are too large.