### PR TITLE
Do not include "longintrepr.h"

### DIFF
--- a/src/fpylll/gmp/pylong.pxd
+++ b/src/fpylll/gmp/pylong.pxd
@@ -3,7 +3,7 @@
 Various functions to deal with conversion mpz <-> Python int/long
 """
 
-cdef extern from "longintrepr.h":
+cdef extern from "Python.h":
     cdef _PyLong_New(Py_ssize_t s)
     cdef long PyLong_SHIFT
     ctypedef unsigned int digit


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/3.11.html
https://github.com/python/cpython/issues/79315

Fixes #230 