### PR TITLE
Fix error ignored during fplll compilation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,7 @@ make clean
 make $jobs
 
 retval=$?
-if [$retval -ne 0 ]; then
+if [ $retval -ne 0 ]; then
     echo "Making fplll failed."
     echo "Check the logs above - they'll contain more information."
     exit 2 # 2 is the exit value if building fplll fails as a result of make $jobs.
@@ -73,7 +73,7 @@ fi
 
 make install
 
-if [$retval -ne 0 ]; then
+if [ $retval -ne 0 ]; then
     echo "Make install failed for fplll."
     echo "Check the logs above - they'll contain more information."
     exit 3 # 3 is the exit value if installing fplll failed.


### PR DESCRIPTION
Hi, 

I noticed when testing the bootstrap script and custom changes in fplll that errors during the compilation of fplll are ignored by the script.
This is due to an error in the spacing, the same as the one fixed some time ago in g6k, see https://github.com/fplll/g6k/pull/86.