### PR TITLE
Update README to remove Travis.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,7 +296,8 @@ from the top-level directory which runs all tests in ``tests/test_*.py``. We run
 
     $ (fpylll) flake8 --max-line-length=120 --max-complexity=16 --ignore=E22,E241 src
 
-Note that **fpylll** supports Python 2 and 3. In particular, tests are run using Python 2.7 and 3.5. See `.travis.yml <https://github.com/fplll/fpylll/blob/master/.travis.yml>`_ for details on automated testing.
+Note that **fpylll** supports Python 3. In particular, tests are run using Python 3.8, 3.9 and 3.10. See `.tests.yml <https://github.com/fplll/fpylll/blob/master/.github/workflows/tests.yml>`_ for details on automated testing.
+
 
 Attribution & License
 ---------------------


### PR DESCRIPTION
FWIW: I also think that fpylll dropped support for Python 2 a while ago (and tests definitely don't use it) but I'm not sure. Feel free to remove that bit if it's not strictly true. 