### PR TITLE
Declare build deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools",
+            "Cython",
+            "cysignals"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ try:
     from setuptools.command.build_ext import build_ext as _build_ext
     from setuptools.core import setup
     from setuptools.extension import Extension as _Extension
-    aux_setup_kwds = {"install_requires": ["Cython", "cysignals"]}
+    aux_setup_kwds = {"install_requires": ["cysignals"]}
 except ImportError:
     from distutils.command.build_ext import build_ext as _build_ext
     from distutils.core import setup


### PR DESCRIPTION
... and remove Cython from the runtime dependencies (`install_requires`); it is only needed at build time.