### PR TITLE
fix: typo in gmp/pycore_long 

### DIFF
--- a/src/fpylll/gmp/pycore_long.h
+++ b/src/fpylll/gmp/pycore_long.h
@@ -89,7 +89,7 @@ _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
 {
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9)
 // The function Py_SET_SIZE is defined starting with python 3.9.
-    Py_SIZE(o) = size;
+    Py_SIZE(op) = size;
 #else
     Py_SET_SIZE(op, sign < 0 ? -size : size);
 #endif


### PR DESCRIPTION
Related to #262 

Locally, after fixing this typo, I'm able to manually install the package. 
We need to cut another minor version release to PyPI and try to `pip wheel` on the new release to see if the installation error goes away (in which case we can close the linked issue)

Either way, this appears to be a clear typo that should be fixed.