### PR TITLE
Fixes in fpylll.algorithms.babai

### DIFF
--- a/src/fpylll/algorithms/babai.py
+++ b/src/fpylll/algorithms/babai.py
@@ -17,6 +17,8 @@ def babai(B, t, *args, **kwargs):
 
     :param B: Input lattice basis.
     :param target: Target point (∈ ZZ^n)
+    :param args: Passed onto LLL.reduction
+    :param kwargs: Passed onto LLL.reduction
     :returns coordinates of the solution vector:
 
     This implementation is more numerically stable compared to the one offered by `MatGSO.babai()`.

--- a/src/fpylll/algorithms/babai.py
+++ b/src/fpylll/algorithms/babai.py
@@ -8,10 +8,10 @@ Babai's Nearest Plane algorithm
 """
 
 from fpylll import IntegerMatrix, LLL
-from math import ceil
+from math import isqrt
 
 
-def babai(B, t):
+def babai(B, t, *args, **kwargs):
     """
     Run Babai's Nearest Plane algorithm by running LLL.
 
@@ -46,13 +46,14 @@ def babai(B, t):
             A[i, j] = B[i, j]
 
     # make sure the input is LLL reduced before reading the norm of the last vector
-    LLL.reduction(A)
+    LLL.reduction(A, *args, **kwargs)
     # zero vector at the end
     A.swap_rows(0, B.nrows)
 
     for j in range(B.ncols):
         A[-1, j] = t[j]
-    A[-1, -1] = ceil(A[-2].norm())
+    # precise norm
+    A[-1, -1] = isqrt(sum(x**2 for x in A[-2])) + 1
 
     LLL.reduction(A)  # now call LLL to run Babai
 

--- a/src/fpylll/algorithms/babai.py
+++ b/src/fpylll/algorithms/babai.py
@@ -57,7 +57,7 @@ def babai(B, t, *args, **kwargs):
     # precise norm
     A[-1, -1] = isqrt(sum(x**2 for x in A[-2])) + 1
 
-    LLL.reduction(A)  # now call LLL to run Babai
+    LLL.reduction(A, *args, **kwargs)  # now call LLL to run Babai
 
     v = [0] * len(t)
     if A[-1, -1] > 0:

--- a/src/fpylll/algorithms/babai.py
+++ b/src/fpylll/algorithms/babai.py
@@ -54,7 +54,7 @@ def babai(B, t, *args, **kwargs):
 
     for j in range(B.ncols):
         A[-1, j] = t[j]
-    # precise norm
+    # precise norm, +1 to make sure it's not too small, too big doesn't matter
     A[-1, -1] = isqrt(sum(x**2 for x in A[-2])) + 1
 
     LLL.reduction(A, *args, **kwargs)  # now call LLL to run Babai


### PR DESCRIPTION
This PR contains one fix and one improvement.

- The fixed issue is that in `fpylll.algorithms.babai`, when the norm of the largest vector is calculated, `ceil(A[-2].norm())`  is used which casts the value to a double after which it is rounded. This is prone to large imprecision issues and when sufficiently large integers are used it may lead to issues with infinity. We instead opt for calculating the norm in Python and using `math.isqrt` which is precise.
- Extra arguments and keyword arguments passed to `babai` will now also be passed onto `LLL.reduction`, which could be useful in some cases.