### PR TITLE
Issue #278: Reference functional cysignals version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = ["setuptools",
             "Cython",
-            "cysignals"]
+            "cysignals<1.12.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
`cysignals` version 1.12.0 appears to be broken when building this package (see issue #278). This forces builds that consume `pyproject.toml` (e.g. poetry based builds) to use a `cysignals` version that is not broken.

I have verified this fixes poetry builds and installs locally, happy to also run any other tests or validation needed.