### PR TITLE
.github/workflows/pypi-publish.yml: New

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        description: 'Workflow run id'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "dist"
+          path: dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.inputs.run-id }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-wheels"
+          path: dist
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.inputs.run-id }}
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          verbose: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,6 +13,9 @@ jobs:
     # https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing
     permissions:
       id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fpylll
 
     steps:
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing
+    permissions:
+      id-token: write
+
     steps:
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
This new workflow can be invoked manually. It downloads the distributions built by a run of `release.yml` and uploads them to PyPI. @malb 

