### PR TITLE
Update bootstrap.sh & setup.py

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -79,7 +79,7 @@ cd ..
 # Install FPyLLL
 
 $PYTHON setup.py clean
-if ! $PYTHON setup.py build $jobs || $PYTHON setup.py build_ext; then
+if ! ( $PYTHON setup.py build $jobs || $PYTHON setup.py build_ext ); then
     echo "Failed to build FPyLLL!"
     echo "Check the logs above - they'll contain more information."
     exit 5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import shlex
 
 try:
     from itertools import ifilter as filter
@@ -24,7 +23,7 @@ except ImportError:
 from ast import parse
 
 with open(os.path.join('..', 'src', 'fpylll', '__init__.py')) as f:
-    __version__ = parse(next(filter(lambda line: line.startswith('__version__'), f))).body[0].value.s
+    __version__ = parse(next(filter(lambda line: line.startswith('__version__'), f))).body[0].value.value
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = ["setuptools",
-            "Cython",
-            "cysignals<1.12.0"]
+            "Cython>=3.0",
+            "cysignals"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
 Cython>=3.0
+cysignals
 pytest
-cysignals<1.12.0
 black

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class build_ext(_build_ext, object):
                 "libraries": ["gmp", "mpfr", "fplll"],
                 "extra_compile_args": ["-std=c++11"] + cxxflags,
                 "extra_link_args": ["-std=c++11"],
-                "define_macros": [("__PYX_EXTERN_C", 'extern "C++"')],
+                "define_macros": [("CYTHON_EXTERN_C", 'extern "C++"')],
             }
 
             if def_vars["HAVE_QD"]:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import platform
 import subprocess
 import sys
 import io
+from ast import parse
+from copy import copy
 
 if "READTHEDOCS" in os.environ:
     # When building with readthedocs, install the dependencies too.
@@ -19,9 +21,6 @@ try:
 except ImportError:
     pass  # python 3
 
-from os import path
-from ast import parse
-
 try:
     from setuptools.command.build_ext import build_ext as _build_ext
     from setuptools.core import setup
@@ -32,8 +31,6 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension as _Extension
     aux_setup_kwds = {}
-
-from copy import copy
 
 try:
     FileNotFoundError
@@ -221,10 +218,11 @@ extensions = [
 
 # VERSION
 
-with open(path.join("src", "fpylll", "__init__.py")) as f:
+with open(os.path.join("src", "fpylll", "__init__.py")) as f:
     __version__ = (
-        parse(next(filter(lambda line: line.startswith("__version__"), f))).body[0].value.s
+        parse(next(filter(lambda line: line.startswith("__version__"), f))).body[0].value.value
     )
+
 # FIRE
 
 


### PR DESCRIPTION
- only append once all code to fpylll-env/bin/activate so deactivating is not necessary
- pick up on return code of `make clean` in FPLLL, like G6K does.
- fix DeprecationWarning in setup.py and docs/conf.py for getting `__version__`
- depend on most recent cysignals (1.12.2) again as this one works again.
- change return values of bootstrap.sh to make all errors have different ones

Note: $retval was not updated after `make install` previously.

Closes: #278