### PR TITLE
long is not longer supported in Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN cd fpylll && \
     python3 setup.py -q install && \
     cd .. && \
     rm -rf fpylll
-    
+

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ For a quick tour of the library, you can check out the `tutorial <https://github
 How to cite
 -----------
 
-.. code-block:: 
+.. code-block::
 
     @unpublished{fpylll,
         author = {The {FPLLL} development team},

--- a/docs/example-gauss-circle-problem.rst
+++ b/docs/example-gauss-circle-problem.rst
@@ -63,7 +63,7 @@ The parameter `nr_solutions` is by default `1.` If we set say, `{\rm{nr\_solutio
   >>> def n(radius):
   ...   dim = 2
   ...   nr = ceil(pi*radius**2 + 2*sqrt(2)*pi*radius)
-  ...   A = IntegerMatrix.idenity(dim) 
+  ...   A = IntegerMatrix.identity(dim)
   ...   M = MatGSO(A)
   ...   _ = M.update_gso()
   ...   enum = Enumeration(M,nr_solutions = nr)

--- a/docs/example-linear-diophantine-equations.rst
+++ b/docs/example-linear-diophantine-equations.rst
@@ -41,10 +41,10 @@ where `N_1`, `N_2` are some positive integers. Say `(x_1,x_2,...,x_n,x_{n+1},x_{
     ...     M[i, -1] = a[i]*N2
     ...     M[i,  i] = 1
     ...
-  
+
     >>> M[-1, -2] = N1
     >>> M[-1, -1] = -a0 * N2
- 
+
 
 We can now apply LLL::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 Overview
-========  
-  
+========
+
 .. include:: ../README.rst
 
 Modules
@@ -10,7 +10,7 @@ Modules
   :maxdepth: 2
 
   modules
-             
+
 Indices and Tables
 ==================
 

--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -48,18 +48,18 @@ cdef int assign_mpz(mpz_t& t, value) except -1:
     if isinstance(value, int) and PY_MAJOR_VERSION == 2:
             mpz_set_si(t, PyInt_AS_LONG(value))
             return 0
-    if isinstance(value, long):
+    if isinstance(value, int):
         mpz_set_pylong(t, value)
         return 0
     if have_sage:
         if isinstance(value, Integer):
-            value = long(value)
+            value = int(value)
             mpz_set_pylong(t, value)
             return 0
 
     IF HAVE_NUMPY:
         if have_numpy and is_numpy_integer(value):
-            value = long(value)
+            value = int(value)
             mpz_set_pylong(t, value)
             return 0
 

--- a/src/fpylll/io.pyx
+++ b/src/fpylll/io.pyx
@@ -44,7 +44,7 @@ cdef int assign_Z_NR_mpz(Z_NR[mpz_t]& t, value) except -1:
 cdef int assign_mpz(mpz_t& t, value) except -1:
     """
     Assign Python integer to Z_NR[mpz_t]
-    """     
+    """
     if isinstance(value, int) and PY_MAJOR_VERSION == 2:
             mpz_set_si(t, PyInt_AS_LONG(value))
             return 0


### PR DESCRIPTION
This may be related to https://github.com/fplll/fpylll/pull/293

It appears I/O was trying to cast values to python integers using `long(value)`, but that is no longer supported (use `int(value)`) in Python 3.x (see https://peps.python.org/pep-0237/ ).

I'm not sure how this seemed to work before, perhaps because there was a try/catch around it in `assign_Z_NR_mpz`?