### PR TITLE
pyproject.toml: Require Cython < 3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools",
-            "Cython>=3.0",
+            "Cython>=3.0,<3.1",
             "cysignals",
             "numpy"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See https://github.com/passagemath/passagemath/pull/651 - fpylll cannot be built with Cython 3.1.0b0.

I suggest to release an fpylll version with an upper version bound on Cython before Cython 3.1 is released.
