### PR TITLE
add cysignals dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,6 +246,9 @@ setup(
     ext_modules=extensions,
     package_dir={"": "src"},
     packages=["fpylll", "fpylll.gmp", "fpylll.fplll", "fpylll.algorithms", "fpylll.tools"],
+    install_requires = [
+        "cysignals",
+    ],
     license="GNU General Public License, version 2 or later",
     long_description=readme_to_long_description(),
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
fpylll requires cysignals at runtime, but the published wheels do not declare it as a dependency

```
$ pip install fpylll
$ python3 -c "import fpylll"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import fpylll
  File "/usr/local/lib/python3.14/dist-packages/fpylll/__init__.py", line 3, in <module>
    from .fplll.integer_matrix import IntegerMatrix
  File "src/fpylll/fplll/integer_matrix.pyx", line 1, in init fpylll.fplll.integer_matrix
    # -*- coding: utf-8 -*-
ModuleNotFoundError: No module named 'cysignals'
```

fix: add cysignals as a dependency in setup.py