### PR TITLE
add `except +` to `bkz_reduction` and `hkz_reduction`

### DIFF
--- a/src/fpylll/fplll/fplll.pxd
+++ b/src/fpylll/fplll/fplll.pxd
@@ -993,9 +993,9 @@ cdef extern from "fplll/fplll.h" namespace "fplll":
                       int precision, int flags) nogil
 
     int bkz_reduction(ZZ_mat[mpz_t] *b, ZZ_mat[mpz_t] *u,
-                      BKZParam &param, FloatType float_type, int precision) nogil
-    int bkz_reduction(ZZ_mat[mpz_t] *b, int block_size, int flags, FloatType float_type, int precision) nogil
+                      BKZParam &param, FloatType float_type, int precision) except + nogil
+    int bkz_reduction(ZZ_mat[mpz_t] *b, int block_size, int flags, FloatType float_type, int precision) except + nogil
 
-    int hkz_reduction(ZZ_mat[mpz_t] b) nogil
+    int hkz_reduction(ZZ_mat[mpz_t] b) except + nogil
 
     const char* get_red_status_str(int status) nogil


### PR DESCRIPTION
## problem

the two `bkz_reduction` overloads in `fplll.pxd` are declared without `except +`. Cython therefore does not wrap calls to them in a C++ try/catch. when fplll's C++ core throws, the exception crosses the Cython boundary uncaught, triggering `std::terminate()` → `abort()` → `SIGABRT`

on Python 3.12 and Python 3.13 this escalates to a fatal SIGSEGV due to a separate ABI incompatibility in cysignals (the signal handler tries to build a Python traceback, but no Python exception has been set → NULL pointer dereference)

with this change, Cython generates a try/catch around the C++ call. the C++ exception is converted to a clean Python `RuntimeError`

note that `svp_reduction` in the same file already has `except +`

## how to reproduce

```bash
docker run --rm python:3.13-slim sh -c '
  pip install -q cysignals fpylll && python -c "
from fpylll import IntegerMatrix, LLL, BKZ
Q = 1 << 60
A = IntegerMatrix(4, 4)
A[0,0] = Q;  A[0,1] = Q//3
A[1,0] = 5;  A[1,1] = -3
A[2,1] = 9;  A[2,2] = -4
A[3,2] = 3;  A[3,3] = 2
LLL.reduction(A, delta=0.99)
BKZ.reduction(A, BKZ.Param(block_size=2, delta=0.99))
"'
```

output:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  infinite loop in babai
------------------------------------------------------------------------
/usr/local/lib/python3.13/site-packages/cysignals/signals.cpython-313-x86_64-linux-gnu.so(+0x8495) [0x720e7db59495]
/usr/local/lib/python3.13/site-packages/cysignals/signals.cpython-313-x86_64-linux-gnu.so(+0x8536) [0x720e7db59536]
/usr/local/lib/python3.13/site-packages/cysignals/signals.cpython-313-x86_64-linux-gnu.so(+0x8904) [0x720e7db59904]
/lib/x86_64-linux-gnu/libc.so.6(+0x3fdf0) [0x720e7f984df0]
/usr/local/bin/../lib/libpython3.13.so.1.0(PyTraceBack_Here+0x43) [0x720e7fcf8e63]
/usr/local/lib/python3.13/site-packages/fpylll/fplll/bkz.cpython-313-x86_64-linux-gnu.so(+0x13557) [0x720e7d852557]
/usr/local/lib/python3.13/site-packages/fpylll/fplll/bkz.cpython-313-x86_64-linux-gnu.so(+0x15b1d) [0x720e7d854b1d]
/usr/local/lib/python3.13/site-packages/fpylll/fplll/bkz.cpython-313-x86_64-linux-gnu.so(+0x163eb) [0x720e7d8553eb]
/usr/local/bin/../lib/libpython3.13.so.1.0(PyObject_Vectorcall+0x5c) [0x720e7fcc397c]
/usr/local/bin/../lib/libpython3.13.so.1.0(_PyEval_EvalFrameDefault+0x3b4b) [0x720e7fcd4ffb]
/usr/local/bin/../lib/libpython3.13.so.1.0(PyEval_EvalCode+0xb4) [0x720e7fd65794]
/usr/local/bin/../lib/libpython3.13.so.1.0(+0x267a13) [0x720e7fda2a13]
/usr/local/bin/../lib/libpython3.13.so.1.0(+0x2648ca) [0x720e7fd9f8ca]
/usr/local/bin/../lib/libpython3.13.so.1.0(+0x2607de) [0x720e7fd9b7de]
/usr/local/bin/../lib/libpython3.13.so.1.0(+0x2606b3) [0x720e7fd9b6b3]
/usr/local/bin/../lib/libpython3.13.so.1.0(Py_RunMain+0x4e7) [0x720e7fd9a8d7]
/usr/local/bin/../lib/libpython3.13.so.1.0(Py_BytesMain+0x3c) [0x720e7fd5314c]
/lib/x86_64-linux-gnu/libc.so.6(+0x29ca8) [0x720e7f96eca8]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x720e7f96ed65]
python(_start+0x21) [0x612131441071]
------------------------------------------------------------------------
Attaching gdb to process id 10.
Cannot find gdb installed
GDB is not installed.
Install gdb for enhanced tracebacks.
------------------------------------------------------------------------
Unhandled SIGSEGV: A segmentation fault occurred.
This probably occurred because a *compiled* module has a bug
in it and is not properly wrapped with sig_on(), sig_off().
Python will now terminate.
------------------------------------------------------------------------
Segmentation fault (core dumped)
```

## note

the SIGSEGV does not reproduce on Python 3.14, but this is coincidental, the fpylll 0.6.4 cp314 wheel happened to be compiled against cysignals 1.12.6 headers (because 1.12.6 was the first cysignals version to support Python 3.14). fplll's C++ exception still reaches `std::terminate()`, it just doesn't escalate to a SIGSEGV